### PR TITLE
Build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,10 @@
 
 # CMAKE File for Albany building against an installed Trilinos
 
-cmake_minimum_required(VERSION 2.7)
+cmake_minimum_required(VERSION 2.8)
 include(CMakeDependentOption)
+
+project(Albany CXX C Fortran)
 
 # Error check up front
 #IF (NOT DEFINED ALBANY_TRILINOS_DIR)
@@ -41,7 +43,7 @@ MESSAGE("   Trilinos_BIN_DIRS = ${Trilinos_BIN_DIRS}")
 MESSAGE("   Trilinos_TPL_LIST = ${Trilinos_TPL_LIST}")
 #MESSAGE("   Trilinos_TPL_INCLUDE_DIRS = ${Trilinos_TPL_INCLUDE_DIRS}")
 #MESSAGE("   Trilinos_TPL_LIBRARIES = ${Trilinos_TPL_LIBRARIES}")
-MESSAGE("   Trilinos_TPL_LIBRARY_DIRS = ${Trilinos_TPL_LIBRARY_DIRS}")
+#MESSAGE("   Trilinos_TPL_LIBRARY_DIRS = ${Trilinos_TPL_LIBRARY_DIRS}")
 MESSAGE("   Trilinos_BUILD_SHARED_LIBS = ${Trilinos_BUILD_SHARED_LIBS}")
 MESSAGE("   Trilinos_CXX_COMPILER_FLAGS = ${Trilinos_CXX_COMPILER_FLAGS}")
 MESSAGE("End of Trilinos details\n")
@@ -76,10 +78,21 @@ IF (INSTALL_ALBANY)
   include(CMakePackageConfigHelpers)
 ENDIF ()
 
-MESSAGE("Setting and checking of compilers:")
-SET(CMAKE_CXX_COMPILER ${Trilinos_CXX_COMPILER} )
-SET(CMAKE_C_COMPILER ${Trilinos_C_COMPILER} )
-SET(CMAKE_Fortran_COMPILER ${Trilinos_Fortran_COMPILER} )
+# Make sure the compilers match.
+MESSAGE("Checking of compilers:")
+IF(NOT ${Trilinos_CXX_COMPILER} STREQUAL ${CMAKE_CXX_COMPILER})
+  MESSAGE(FATAL_ERROR "C++ compilers don't match (Trilinos: ${Trilinos_CXX_COMPILER}, ${PROJECT_NAME}: ${CMAKE_CXX_COMPILER}).")
+ENDIF()
+IF(NOT ${Trilinos_C_COMPILER} STREQUAL ${CMAKE_C_COMPILER})
+  MESSAGE(FATAL_ERROR "C compilers don't match (Trilinos: ${Trilinos_C_COMPILER}, ${PROJECT_NAME}: ${CMAKE_C_COMPILER}).")
+ENDIF()
+IF(NOT ${Trilinos_Fortran_COMPILER} STREQUAL ${CMAKE_Fortran_COMPILER})
+  MESSAGE(FATAL_ERROR "Fortran compilers don't match (Trilinos: ${Trilinos_Fortran_COMPILER}, ${PROJECT_NAME}: ${CMAKE_Fortran_COMPILER}).")
+ENDIF()
+
+#SET(CMAKE_CXX_COMPILER ${Trilinos_CXX_COMPILER} )
+#SET(CMAKE_C_COMPILER ${Trilinos_C_COMPILER} )
+#SET(CMAKE_Fortran_COMPILER ${Trilinos_Fortran_COMPILER} )
 
 # Build Albany as shared libraries if Trilinos was compiled that way
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -584,6 +584,7 @@ endif ()
 
 
 add_library(albanyLib ${Albany_LIBRARY_TYPE} ${SOURCES} ${HEADERS})
+target_link_libraries(albanyLib ${Trilinos_LIBRARIES})
 
 
 # Add Albany external libraries

--- a/src/disc/stk/CMakeLists.txt
+++ b/src/disc/stk/CMakeLists.txt
@@ -59,6 +59,7 @@ include_directories (${Trilinos_INCLUDE_DIRS}  ${Trilinos_TPL_INCLUDE_DIRS}
   )
 
 add_library(albanySTK ${Albany_LIBRARY_TYPE} ${SOURCES} ${HEADERS})
+target_link_libraries(albanySTK ${Trilinos_LIBRARIES})
 
 set_target_properties(albanySTK PROPERTIES PUBLIC_HEADER "${HEADERS}")
 


### PR DESCRIPTION
This pull request adds `project(Albany CXX C Fortran)`, a command that sets important CMake-internal variables crucial for `find_package()`. It also enforces proper compiler selection which now has to happen on terminal level when `cmake` is invoked, e.g.,
```
CXX=mpicxx \
CC=mpicc \
FC=mpif90 \
cmake \
  ../../source
```
If the selected compilers don't match the Trilinos compilers, an error is thrown.
With the changes of this PR, `find_package(Trilinos REQUIRED)` works are expected.

The PR also fixes underlinking in `libAlbany` and `libAlbanySTK` (see bug #3).