### PR TITLE
explicitly instantiate ParallelConstitutiveModel

### DIFF
--- a/src/LCM/models/CrystalPlasticityModel.cpp
+++ b/src/LCM/models/CrystalPlasticityModel.cpp
@@ -8,6 +8,14 @@
 
 #include "CrystalPlasticityModel.hpp"
 #include "CrystalPlasticityModel_Def.hpp"
+#include "../parallel_models/ParallelConstitutiveModel_Def.hpp"
+
+template<typename EvalT, typename Traits>
+LCM::CrystalPlasticityModel<EvalT,Traits>::CrystalPlasticityModel(Teuchos::ParameterList* p,
+    const Teuchos::RCP<Albany::Layouts>& dl):
+  LCM::ParallelConstitutiveModel<EvalT, Traits, CrystalPlasticityKernel<EvalT, Traits>>(p, dl)
+{}
 
 PHAL_INSTANTIATE_TEMPLATE_CLASS(LCM::CrystalPlasticityKernel)
+PHAL_INSTANTIATE_TEMPLATE_CLASS(LCM::CrystalPlasticityModel)
 

--- a/src/LCM/models/CrystalPlasticityModel.hpp
+++ b/src/LCM/models/CrystalPlasticityModel.hpp
@@ -314,8 +314,11 @@ private:
 };
 
 template<typename EvalT, typename Traits>
-using CrystalPlasticityModel
-  = LCM::ParallelConstitutiveModel<EvalT, Traits, CrystalPlasticityKernel<EvalT, Traits>>;
+class CrystalPlasticityModel : public LCM::ParallelConstitutiveModel<EvalT, Traits, CrystalPlasticityKernel<EvalT, Traits>> {
+public:
+  CrystalPlasticityModel(Teuchos::ParameterList* p,
+      const Teuchos::RCP<Albany::Layouts>& dl);
+};
 
 }
 

--- a/src/LCM/models/J2MiniSolver.cpp
+++ b/src/LCM/models/J2MiniSolver.cpp
@@ -8,6 +8,13 @@
 
 #include "J2MiniSolver.hpp"
 #include "J2MiniSolver_Def.hpp"
+#include "../parallel_models/ParallelConstitutiveModel_Def.hpp"
+
+template<typename EvalT, typename Traits>
+LCM::J2MiniSolver<EvalT,Traits>::J2MiniSolver(Teuchos::ParameterList* p,
+    const Teuchos::RCP<Albany::Layouts>& dl):
+  LCM::ParallelConstitutiveModel<EvalT, Traits, J2MiniKernel<EvalT, Traits>>(p, dl)
+{}
 
 PHAL_INSTANTIATE_TEMPLATE_CLASS(LCM::J2MiniKernel)
-
+PHAL_INSTANTIATE_TEMPLATE_CLASS(LCM::J2MiniSolver)

--- a/src/LCM/models/J2MiniSolver.hpp
+++ b/src/LCM/models/J2MiniSolver.hpp
@@ -86,7 +86,11 @@ struct J2MiniKernel : public ParallelKernel<EvalT, Traits>
 };
 
 template<typename EvalT, typename Traits>
-using J2MiniSolver = LCM::ParallelConstitutiveModel<EvalT, Traits, J2MiniKernel<EvalT, Traits>>;
+class J2MiniSolver : public LCM::ParallelConstitutiveModel<EvalT, Traits, J2MiniKernel<EvalT, Traits>> {
+public:
+  J2MiniSolver(Teuchos::ParameterList* p,
+      const Teuchos::RCP<Albany::Layouts>& dl);
+};
 
 }
 #endif // LCM_J2MiniSolver_hpp

--- a/src/LCM/parallel_models/ParallelConstitutiveModel.hpp
+++ b/src/LCM/parallel_models/ParallelConstitutiveModel.hpp
@@ -179,6 +179,4 @@ protected:
 
 }
 
-#include "ParallelConstitutiveModel_Def.hpp"
-
 #endif

--- a/src/LCM/parallel_models/ParallelNeohookeanModel.cpp
+++ b/src/LCM/parallel_models/ParallelNeohookeanModel.cpp
@@ -8,5 +8,13 @@
 
 #include "ParallelNeohookeanModel.hpp"
 #include "ParallelNeohookeanModel_Def.hpp"
+#include "../parallel_models/ParallelConstitutiveModel_Def.hpp"
+
+template<typename EvalT, typename Traits>
+LCM::ParallelNeohookeanModel<EvalT,Traits>::ParallelNeohookeanModel(Teuchos::ParameterList* p,
+    const Teuchos::RCP<Albany::Layouts>& dl):
+  LCM::ParallelConstitutiveModel<EvalT, Traits, NeohookeanKernel<EvalT, Traits>>(p, dl)
+{}
 
 PHAL_INSTANTIATE_TEMPLATE_CLASS(LCM::NeohookeanKernel)
+PHAL_INSTANTIATE_TEMPLATE_CLASS(LCM::ParallelNeohookeanModel)

--- a/src/LCM/parallel_models/ParallelNeohookeanModel.hpp
+++ b/src/LCM/parallel_models/ParallelNeohookeanModel.hpp
@@ -65,7 +65,11 @@ struct NeohookeanKernel : public ParallelKernel<EvalT, Traits>
 };
 
 template<typename EvalT, typename Traits>
-using ParallelNeohookeanModel = LCM::ParallelConstitutiveModel<EvalT, Traits, NeohookeanKernel<EvalT, Traits>>;
+class ParallelNeohookeanModel : public LCM::ParallelConstitutiveModel<EvalT, Traits, NeohookeanKernel<EvalT, Traits>> {
+public:
+  ParallelNeohookeanModel(Teuchos::ParameterList* p,
+      const Teuchos::RCP<Albany::Layouts>& dl);
+};
 
 #if 0
 //! \brief Parallel Neohookean Model


### PR DESCRIPTION
First off, this silences compiler warnings of the
form:

J2MiniSolver.hpp:85:8: warning: inline function
‘void LCM::J2MiniKernel::operator()(int, int) const
[with EvalT = PHAL::AlbanyTraits::DistParamDeriv; Traits = PHAL::AlbanyTraits]’
used but never defined [enabled by default]

And will hopefully help with #9

See the commit message for a very long description.

This is a PR because lots of LCM changes were recently pushed,
and I'm waiting to see how the nightly tests respond to that before
pushing this as well to master.