### PR TITLE
Consistent treatment of thermomechanics in some LCM material models

### DIFF
--- a/src/LCM/models/AnisotropicViscoplasticModel_Def.hpp
+++ b/src/LCM/models/AnisotropicViscoplasticModel_Def.hpp
@@ -179,6 +179,24 @@ computeState(typename Traits::EvalData workset,
 
       // fill local tensors
       F.fill(def_grad, cell, pt,0,0);
+
+      // Mechanical deformation gradient
+      auto Fm = minitensor::Tensor<ScalarT>(F);
+      if (have_temperature_) {
+        // Compute the mechanical deformation gradient Fe based on the
+        // multiplicative decomposition of the deformation gradient
+        //
+        //            F = Fm.Ft => Fm = F.inv(Ft)
+        //
+        // where Ft is the thermal part of F, given as
+        //
+        //     Ft = Le * I = exp(alpha * dtemp) * I
+        //
+        ScalarT dtemp = temperature_(cell, pt) - ref_temperature_;
+        ScalarT thermal_stretch = std::exp(expansion_coeff_ * dtemp);
+        Fm /= thermal_stretch;
+      }
+
       //Fpn.fill( &Fpold(cell,pt,int(0),int(0)) );
       for (int i(0); i < num_dims_; ++i) {
         for (int j(0); j < num_dims_; ++j) {
@@ -189,9 +207,9 @@ computeState(typename Traits::EvalData workset,
       // compute trial state
       // compute the Kirchhoff stress in the current configuration
       //
-      Fe = F * minitensor::inverse(Fpn);
+      Fe = Fm * minitensor::inverse(Fpn);
       Cpinv = minitensor::inverse(Fpn) * minitensor::transpose(minitensor::inverse(Fpn));
-      be = F * Cpinv * minitensor::transpose(F);
+      be = Fm * Cpinv * minitensor::transpose(Fm);
       ScalarT Je = std::sqrt( minitensor::det(be));
       s = mu * minitensor::dev(be);
       p = 0.5 * bulk * (Je * Je - 1.);
@@ -299,24 +317,6 @@ computeState(typename Traits::EvalData workset,
       }
     }
   }
-
-  if (have_temperature_) {
-    for (int cell(0); cell < workset.numCells; ++cell) {
-      for (int pt(0); pt < num_pts_; ++pt) {
-        F.fill(def_grad,cell,pt,0,0);
-        ScalarT J = minitensor::det(F);
-        sigma.fill(stress,cell,pt,0,0);
-        sigma -= 3.0 * bulk * expansion_coeff_ * (1.0 + 1.0 / (J*J))
-          * (temperature_(cell,pt) - ref_temperature_) * I;
-        for (int i = 0; i < num_dims_; ++i) {
-          for (int j = 0; j < num_dims_; ++j) {
-            stress(cell, pt, i, j) = sigma(i, j);
-          }
-        }
-      }
-    }
-  }
-
 }
 //------------------------------------------------------------------------------
 }

--- a/src/LCM/models/AnisotropicViscoplasticModel_Def.hpp
+++ b/src/LCM/models/AnisotropicViscoplasticModel_Def.hpp
@@ -183,7 +183,7 @@ computeState(typename Traits::EvalData workset,
       // Mechanical deformation gradient
       auto Fm = minitensor::Tensor<ScalarT>(F);
       if (have_temperature_) {
-        // Compute the mechanical deformation gradient Fe based on the
+        // Compute the mechanical deformation gradient Fm based on the
         // multiplicative decomposition of the deformation gradient
         //
         //            F = Fm.Ft => Fm = F.inv(Ft)
@@ -192,6 +192,8 @@ computeState(typename Traits::EvalData workset,
         //
         //     Ft = Le * I = exp(alpha * dtemp) * I
         //
+        // Le is the thermal stretch and alpha the coefficient of thermal
+        // expansion.
         ScalarT dtemp = temperature_(cell, pt) - ref_temperature_;
         ScalarT thermal_stretch = std::exp(expansion_coeff_ * dtemp);
         Fm /= thermal_stretch;

--- a/src/LCM/models/ElastoViscoplasticModel_Def.hpp
+++ b/src/LCM/models/ElastoViscoplasticModel_Def.hpp
@@ -412,7 +412,7 @@ computeState(typename Traits::EvalData workset,
         // Mechanical deformation gradient
         auto Fm = minitensor::Tensor<ScalarT>(F);
         if (have_temperature_) {
-          // Compute the mechanical deformation gradient Fe based on the
+          // Compute the mechanical deformation gradient Fm based on the
           // multiplicative decomposition of the deformation gradient
           //
           //            F = Fm.Ft => Fm = F.inv(Ft)
@@ -421,6 +421,8 @@ computeState(typename Traits::EvalData workset,
           //
           //     Ft = Le * I = exp(alpha * dtemp) * I
           //
+          // Le = exp(alpha*dtemp) is the thermal stretch and alpha the
+          // coefficient of thermal expansion.
           ScalarT dtemp = temperature_(cell, pt) - ref_temperature_;
           ScalarT thermal_stretch = std::exp(expansion_coeff_ * dtemp);
           Fm /= thermal_stretch;

--- a/src/LCM/models/HyperelasticDamageModel_Def.hpp
+++ b/src/LCM/models/HyperelasticDamageModel_Def.hpp
@@ -107,7 +107,7 @@ computeState(typename Traits::EvalData workset,
       // Mechanical deformation gradient
       auto Fm = minitensor::Tensor<ScalarT>(F);
       if (have_temperature_) {
-        // Compute the mechanical deformation gradient Fe based on the
+        // Compute the mechanical deformation gradient Fm based on the
         // multiplicative decomposition of the deformation gradient
         //
         //            F = Fm.Ft => Fm = F.inv(Ft)
@@ -116,6 +116,8 @@ computeState(typename Traits::EvalData workset,
         //
         //     Ft = Le * I = exp(alpha * dtemp) * I
         //
+        // Le = exp(alpha*dtemp) is the thermal stretch and alpha the
+        // coefficient of thermal expansion.
         ScalarT dtemp = temperature_(cell, pt) - ref_temperature_;
         ScalarT thermal_stretch = std::exp(expansion_coeff_ * dtemp);
         Fm /= thermal_stretch;

--- a/src/LCM/models/J2MiniSolver_Def.hpp
+++ b/src/LCM/models/J2MiniSolver_Def.hpp
@@ -246,7 +246,7 @@ J2MiniKernel<EvalT, Traits>::operator()(int cell, int pt) const
   // Mechanical deformation gradient
   auto Fm = Tensor(F);
   if (have_temperature_) {
-    // Compute the mechanical deformation gradient Fe based on the
+    // Compute the mechanical deformation gradient Fm based on the
     // multiplicative decomposition of the deformation gradient
     //
     //            F = Fm.Ft => Fm = F.inv(Ft)
@@ -255,6 +255,8 @@ J2MiniKernel<EvalT, Traits>::operator()(int cell, int pt) const
     //
     //     Ft = Le * I = exp(alpha * dtemp) * I
     //
+    // Le = exp(alpha*dtemp) is the thermal stretch and alpha the
+    // coefficient of thermal expansion.
     ScalarT dtemp = temperature_(cell, pt) - ref_temperature_;
     ScalarT thermal_stretch = std::exp(expansion_coeff_ * dtemp);
     Fm /= thermal_stretch;

--- a/src/LCM/models/J2Model_Def.hpp
+++ b/src/LCM/models/J2Model_Def.hpp
@@ -166,6 +166,24 @@ J2Model<EvalT, Traits>::computeState(
       Jm23 = std::pow(J(cell, pt), -2. / 3.);
       // fill local tensors
       F.fill(def_grad, cell, pt, 0, 0);
+
+      // Mechanical deformation gradient
+      auto Fm = minitensor::Tensor<ScalarT>(F);
+      if (have_temperature_) {
+        // Compute the mechanical deformation gradient Fe based on the
+        // multiplicative decomposition of the deformation gradient
+        //
+        //            F = Fm.Ft => Fm = F.inv(Ft)
+        //
+        // where Ft is the thermal part of F, given as
+        //
+        //     Ft = Le * I = exp(alpha * dtemp) * I
+        //
+        ScalarT dtemp = temperature_(cell, pt) - ref_temperature_;
+        ScalarT thermal_stretch = std::exp(expansion_coeff_ * dtemp);
+        Fm /= thermal_stretch;
+      }
+
       // Fpn.fill( &Fpold(cell,pt,int(0),int(0)) );
       for (int i(0); i < num_dims_; ++i) {
         for (int j(0); j < num_dims_; ++j) {
@@ -177,7 +195,7 @@ J2Model<EvalT, Traits>::computeState(
       Fpinv = minitensor::inverse(Fpn);
 
       Cpinv = Fpinv * minitensor::transpose(Fpinv);
-      be    = Jm23 * F * Cpinv * minitensor::transpose(F);
+      be    = Jm23 * Fm * Cpinv * minitensor::transpose(Fm);
       s     = mu * minitensor::dev(be);
 
       mubar = minitensor::trace(be) * mu / (num_dims_);
@@ -297,23 +315,6 @@ J2Model<EvalT, Traits>::computeState(
       for (int i(0); i < num_dims_; ++i) {
         for (int j(0); j < num_dims_; ++j) {
           stress(cell, pt, i, j) = sigma(i, j);
-        }
-      }
-    }
-  }
-
-  if (have_temperature_) {
-    for (int cell(0); cell < workset.numCells; ++cell) {
-      for (int pt(0); pt < num_pts_; ++pt) {
-        F.fill(def_grad, cell, pt, 0, 0);
-        ScalarT J = minitensor::det(F);
-        sigma.fill(stress, cell, pt, 0, 0);
-        sigma -= 3.0 * kappa * expansion_coeff_ * (1.0 + 1.0 / (J * J)) *
-                 (temperature_(cell, pt) - ref_temperature_) * I;
-        for (int i = 0; i < num_dims_; ++i) {
-          for (int j = 0; j < num_dims_; ++j) {
-            stress(cell, pt, i, j) = sigma(i, j);
-          }
         }
       }
     }

--- a/src/LCM/models/J2Model_Def.hpp
+++ b/src/LCM/models/J2Model_Def.hpp
@@ -170,7 +170,7 @@ J2Model<EvalT, Traits>::computeState(
       // Mechanical deformation gradient
       auto Fm = minitensor::Tensor<ScalarT>(F);
       if (have_temperature_) {
-        // Compute the mechanical deformation gradient Fe based on the
+        // Compute the mechanical deformation gradient Fm based on the
         // multiplicative decomposition of the deformation gradient
         //
         //            F = Fm.Ft => Fm = F.inv(Ft)
@@ -179,6 +179,8 @@ J2Model<EvalT, Traits>::computeState(
         //
         //     Ft = Le * I = exp(alpha * dtemp) * I
         //
+        // Le = exp(alpha*dtemp) is the thermal stretch and alpha the
+        // coefficient of thermal expansion.
         ScalarT dtemp = temperature_(cell, pt) - ref_temperature_;
         ScalarT thermal_stretch = std::exp(expansion_coeff_ * dtemp);
         Fm /= thermal_stretch;

--- a/src/LCM/models/NeohookeanModel_Def.hpp
+++ b/src/LCM/models/NeohookeanModel_Def.hpp
@@ -109,7 +109,7 @@ computeState(
       // Mechanical deformation gradient
       auto Fm = minitensor::Tensor<ScalarT>(F);
       if (have_temperature_) {
-        // Compute the mechanical deformation gradient Fe based on the
+        // Compute the mechanical deformation gradient Fm based on the
         // multiplicative decomposition of the deformation gradient
         //
         //            F = Fm.Ft => Fm = F.inv(Ft)
@@ -118,6 +118,8 @@ computeState(
         //
         //     Ft = Le * I = exp(alpha * dtemp) * I
         //
+        // Le = exp(alpha*dtemp) is the thermal stretch and alpha the
+        // coefficient of thermal expansion.
         ScalarT dtemp = temperature_(cell, pt) - ref_temperature_;
         ScalarT thermal_stretch = std::exp(expansion_coeff_ * dtemp);
         Fm /= thermal_stretch;

--- a/src/LCM/models/NeohookeanModel_Def.hpp
+++ b/src/LCM/models/NeohookeanModel_Def.hpp
@@ -105,7 +105,24 @@ computeState(
       Jm53 = Jm23 * Jm23 * Jm13;
 
       F.fill(def_grad, cell, pt, 0, 0);
-      b = F * minitensor::transpose(F);
+
+      // Mechanical deformation gradient
+      auto Fm = minitensor::Tensor<ScalarT>(F);
+      if (have_temperature_) {
+        // Compute the mechanical deformation gradient Fe based on the
+        // multiplicative decomposition of the deformation gradient
+        //
+        //            F = Fm.Ft => Fm = F.inv(Ft)
+        //
+        // where Ft is the thermal part of F, given as
+        //
+        //     Ft = Le * I = exp(alpha * dtemp) * I
+        //
+        ScalarT dtemp = temperature_(cell, pt) - ref_temperature_;
+        ScalarT thermal_stretch = std::exp(expansion_coeff_ * dtemp);
+        Fm /= thermal_stretch;
+      }
+      b = Fm * minitensor::transpose(Fm);
       mubar = (1.0 / 3.0) * mu * Jm23 * minitensor::trace(b);
       sigma = 0.5 * kappa * (J - 1.0 / J) * I + mu * Jm53 * minitensor::dev(b);
 
@@ -144,23 +161,6 @@ computeState(
     }
   }
 
-  if (have_temperature_ == true) {
-    for (int cell(0); cell < workset.numCells; ++cell) {
-      for (int pt(0); pt < num_pts_; ++pt) {
-        F.fill(def_grad, cell, pt, 0, 0);
-        ScalarT J = minitensor::det(F);
-        sigma.fill(stress, cell, pt, 0, 0);
-        sigma -= 3.0 * kappa * expansion_coeff_ * (1.0 + 1.0 / (J * J))
-            * (temperature_(cell, pt) - ref_temperature_) * I;
-
-        for (int i = 0; i < num_dims_; ++i) {
-          for (int j = 0; j < num_dims_; ++j) {
-            stress(cell, pt, i, j) = sigma(i, j);
-          }
-        }
-      }
-    }
-  }
 }
 
 } // namespace LCM


### PR DESCRIPTION
Comments:
Rather than subtract the thermal contribution from the updated stress at the
end of the update, remove the thermal contribution to the deformation gradient
at the beginning of the stress update.  Use only the mechanical portion in
the stress update.  See #260 for motivation.

Addresses: #260
Review: @lxmota

Test Summary:
RHEL6, GCC 6.1, OPENMPI 1.10.1
100% tests passed, 0 tests failed out of 192