### PR TITLE
Enable ctest of /tests/small/LCM/Pressure

### DIFF
--- a/tests/small/LCM/Pressure/CMakeLists.txt
+++ b/tests/small/LCM/Pressure/CMakeLists.txt
@@ -14,7 +14,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/tetra4.exo
 get_filename_component(testName ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 # 3. Create the test with this name and standard executable
 if (ALBANY_IFPACK2)
-add_test(${testName}_comp ${AlbanyT.exe} input_comp.yaml)
-add_test(${testName}_tetra4 ${AlbanyT.exe} input_tetra4.yaml)
-add_test(${testName}_tetra10 ${AlbanyT.exe} input_tetra10.yaml)
+add_test(${testName}_comp ${SerialAlbanyT.exe} input_comp.yaml)
+add_test(${testName}_tetra4 ${SerialAlbanyT.exe} input_tetra4.yaml)
+add_test(${testName}_tetra10 ${SerialAlbanyT.exe} input_tetra10.yaml)
 endif ()

--- a/tests/small/LCM/Pressure/input_comp.yaml
+++ b/tests/small/LCM/Pressure/input_comp.yaml
@@ -20,19 +20,20 @@ LCM:
       Number: 1
       Parameter 0: 'NBC on SS cl1 for DOF all set (t_x, t_y, t_z)[0]'
     Response Functions:
-      Number: 2
-      Response 0: Solution Average
-      Response 1: Solution Max Value
+      Number: 1
+      Response 0: Solution Min Value
+      ResponseParams 0:
+        Equation: 2
   Discretization:
     Method: Ioss
     Exodus Input File Name: tetra10.exo
-    Exodus Output File Name: tetra10_out.exo
+    Exodus Output File Name: tetra10_comp.exo
     Exodus Solution Name: disp
     Exodus Residual Name: resid
     Use Serial Mesh: true
   Regression Results:
-    Number of Comparisons: 2
-    Test Values: [-1.37227986e-05, 0.05635030]
+    Number of Comparisons: 1
+    Test Values: [-0.3704]
     Absolute Tolerance: 0.00010000
   Piro:
     LOCA:

--- a/tests/small/LCM/Pressure/input_tetra10.yaml
+++ b/tests/small/LCM/Pressure/input_tetra10.yaml
@@ -9,7 +9,7 @@ LCM:
       SDBC on NS fix for DOF Y: 0.00000000e+00
       SDBC on NS fix for DOF Z: 0.00000000e+00
     Neumann BCs:
-      NBC on SS cl1 for DOF all set P: [-0.1]
+      NBC on SS cl1 for DOF all set P: [0.1]
     Elastic Modulus:
       Elastic Modulus Type: Constant
       Value: 4000.00000000
@@ -20,9 +20,10 @@ LCM:
       Number: 1
       Parameter 0: NBC on SS cl1 for DOF all set P
     Response Functions:
-      Number: 2
-      Response 0: Solution Average
-      Response 1: Solution Max Value
+      Number: 1
+      Response 0: Solution Min Value
+      ResponseParams 0:
+        Equation: 2
   Discretization:
     Method: Ioss
     Exodus Input File Name: tetra10.exo
@@ -31,8 +32,8 @@ LCM:
     Exodus Residual Name: resid
     Use Serial Mesh: true
   Regression Results:
-    Number of Comparisons: 2
-    Test Values: [-1.37227986e-05, 0.05635030]
+    Number of Comparisons: 1
+    Test Values: [-0.3704]
     Absolute Tolerance: 0.00010000
   Piro:
     LOCA:

--- a/tests/small/LCM/Pressure/input_tetra4.yaml
+++ b/tests/small/LCM/Pressure/input_tetra4.yaml
@@ -9,7 +9,7 @@ LCM:
       SDBC on NS fix for DOF Y: 0.00000000e+00
       SDBC on NS fix for DOF Z: 0.00000000e+00
     Neumann BCs:
-      NBC on SS cl1 for DOF all set P: [-0.1]
+      NBC on SS cl1 for DOF all set P: [0.1]
     Elastic Modulus:
       Elastic Modulus Type: Constant
       Value: 4000.00000000
@@ -20,9 +20,10 @@ LCM:
       Number: 1
       Parameter 0: NBC on SS cl1 for DOF all set P
     Response Functions:
-      Number: 2
-      Response 0: Solution Average
-      Response 1: Solution Max Value
+      Number: 1
+      Response 0: Solution Min Value
+      ResponseParams 0:
+        Equation: 2
   Discretization:
     Method: Ioss
     Exodus Input File Name: tetra4.exo
@@ -31,8 +32,8 @@ LCM:
     Exodus Residual Name: resid
     Use Serial Mesh: true
   Regression Results:
-    Number of Comparisons: 2
-    Test Values: [-1.37227986e-05, 0.05635030]
+    Number of Comparisons: 1
+    Test Values: [-0.1454]
     Absolute Tolerance: 0.00010000
   Piro:
     LOCA:


### PR DESCRIPTION
ctest of /tests/small/LCM/Pressure fails due to incorrect reference solution value. It is fixed after this modification