### PR TITLE
Data types header split

### DIFF
--- a/src/ATO/ATOT_Solver.cpp
+++ b/src/ATO/ATOT_Solver.cpp
@@ -18,6 +18,7 @@ Please remove when issue is resolved
 
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Tpetra_RowMatrixTransposer.hpp"
 
 #include "Albany_SolverFactory.hpp"
 #include "Albany_StateInfoStruct.hpp"
@@ -228,7 +229,7 @@ ATOT::SpatialFilter::buildOperator(
     
     //IKT, FIXME: remove the following creation of filterOperatorTransposeT 
     //once Mark Hoemmen fixes apply method with TRANS mode in Tpetra::CrsMatrix.
-    Tpetra_RowMatrixTransposer transposer(filterOperatorT);
+    Tpetra::RowMatrixTransposer<ST,Tpetra_LO,Tpetra_GO,KokkosNode> transposer(filterOperatorT);
     filterOperatorTransposeT = transposer.createTranspose();
 
   return;

--- a/src/ATO/ATOT_Solver.hpp
+++ b/src/ATO/ATOT_Solver.hpp
@@ -155,8 +155,8 @@ int _writeDesignFrequency;
 int  numDims;
 int _num_parameters; // for sensitiviy analysis(?)
 int _num_responses;  //  ditto
-Teuchos::RCP<Tpetra_LocalMap> _tpetra_param_map;
-Teuchos::RCP<Tpetra_LocalMap> _tpetra_response_map;
+// Teuchos::RCP<Tpetra_LocalMap> _tpetra_param_map;
+// Teuchos::RCP<Tpetra_LocalMap> _tpetra_response_map;
 Teuchos::RCP<const Tpetra_Map>      _tpetra_x_map;
 
 int _numPhysics; // number of sub problems

--- a/src/ATO/ATO_Solver.cpp
+++ b/src/ATO/ATO_Solver.cpp
@@ -18,6 +18,7 @@ Please remove when issue is resolved
 
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Tpetra_RowMatrixTransposer.hpp"
 
 #include "Albany_SolverFactory.hpp"
 #include "Albany_StateInfoStruct.hpp"
@@ -1945,7 +1946,7 @@ ATO::SpatialFilter::buildOperator(
 
     //IKT, FIXME: remove the following creation of filterOperatorTransposeT 
     //once Mark Hoemmen fixes apply method with TRANS mode in Tpetra::CrsMatrix.
-    Tpetra_RowMatrixTransposer transposer(filterOperatorT);
+    Tpetra::RowMatrixTransposer<ST,Tpetra_LO,Tpetra_GO,KokkosNode> transposer(filterOperatorT);
     filterOperatorTransposeT = transposer.createTranspose();
 
   return;

--- a/src/Aeras/Aeras_HVDecorator.cpp
+++ b/src/Aeras/Aeras_HVDecorator.cpp
@@ -122,8 +122,8 @@ Aeras::HVDecorator::HVDecorator(
 //compare the product L*x (L is the Laplace, x is an arbitrary vector)
 //in case of a parallel and serial run.
 #ifdef WRITE_TO_MATRIX_MARKET_TO_MM_FILE
-  Tpetra_MatrixMarket_Writer::writeSparseFile("mass.mm", mass);
-  Tpetra_MatrixMarket_Writer::writeSparseFile("laplace.mm", laplace_);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile("mass.mm", mass);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile("laplace.mm", laplace_);
 #endif
 }
  
@@ -416,9 +416,9 @@ Aeras::HVDecorator::evalModelImpl(
   //writing to MatrixMarket for debug
   char name[100];  //create string for file name
   sprintf(name, "xT_%i.mm", mm_counter);
-  Tpetra_MatrixMarket_Writer::writeDenseFile(name, xT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(name, xT);
   sprintf(name, "xtildeT_%i.mm", mm_counter);
-  Tpetra_MatrixMarket_Writer::writeDenseFile(name, xtildeT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(name, xtildeT);
   mm_counter++; 
 #endif  
 

--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -12,6 +12,7 @@
 #include "Albany_ResponseFactory.hpp"
 #include "Albany_Utils.hpp"
 #include "Teuchos_TimeMonitor.hpp"
+#include <MatrixMarket_Tpetra.hpp>
 
 #if defined(ALBANY_EPETRA)
 #include "EpetraExt_MultiVectorOut.h"
@@ -1295,7 +1296,7 @@ void checkDerivatives(Albany::Application &app, const double time,
     static int ctr = 0;
     std::stringstream ss;
     ss << "dc" << ctr << ".mm";
-    Tpetra_MatrixMarket_Writer::writeDenseFile(ss.str(), mv);
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(ss.str(), mv);
     ++ctr;
   }
 }
@@ -1449,7 +1450,7 @@ void Albany::Application::computeGlobalResidualImplT(
 #ifdef WRITE_TO_MATRIX_MARKET
   char nameResUnscaled[100]; // create string for file name
   sprintf(nameResUnscaled, "resUnscaled%i_residual.mm", countScale);
-  Tpetra_MatrixMarket_Writer::writeDenseFile(nameResUnscaled, fT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(nameResUnscaled, fT);
 #endif
 
   if (scaleBCdofs == false && scale != 1.0) {
@@ -1459,7 +1460,7 @@ void Albany::Application::computeGlobalResidualImplT(
 #ifdef WRITE_TO_MATRIX_MARKET
   char nameResScaled[100]; // create string for file name
   sprintf(nameResScaled, "resScaled%i_residual.mm", countScale);
-  Tpetra_MatrixMarket_Writer::writeDenseFile(nameResScaled, fT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(nameResScaled, fT);
 #endif
 
 #if defined(ALBANY_LCM)
@@ -1485,7 +1486,7 @@ void Albany::Application::computeGlobalResidualImplT(
       char nameScale[100]; // create string for file name
       if (commT->getSize() == 1) {
         sprintf(nameScale, "scale%i.mm", countScale);
-        Tpetra_MatrixMarket_Writer::writeDenseFile(nameScale, scaleVec_);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(nameScale, scaleVec_);
       }
       else {
         // create serial map that puts the whole solution on processor 0
@@ -1503,7 +1504,7 @@ void Albany::Application::computeGlobalResidualImplT(
             Teuchos::rcp(new Tpetra_Vector(serial_map));
         scale_serial->doImport(*scaleVec_, *importOperator, Tpetra::INSERT);
         sprintf(nameScale, "scaleSerial%i.mm", countScale);
-        Tpetra_MatrixMarket_Writer::writeDenseFile(nameScale, scale_serial);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(nameScale, scale_serial);
       }
 #endif
       countScale++;
@@ -1563,12 +1564,12 @@ void Albany::Application::computeGlobalResidualT(
     if (writeToMatrixMarketRes ==
         -1) { // write residual to MatrixMarket every time it arises
       sprintf(name, "rhs%i.mm", countRes);
-      Tpetra_MatrixMarket_Writer::writeDenseFile(name, Teuchos::rcpFromRef(fT));
+      Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(name, Teuchos::rcpFromRef(fT));
     } else {
       if (countRes ==
           writeToMatrixMarketRes) { // write residual only at requested count#
         sprintf(name, "rhs%i.mm", countRes);
-        Tpetra_MatrixMarket_Writer::writeDenseFile(name,
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(name,
                                                    Teuchos::rcpFromRef(fT));
       }
     }
@@ -1759,11 +1760,11 @@ void Albany::Application::computeGlobalJacobianImplT(
 #ifdef WRITE_TO_MATRIX_MARKET
       char nameJacUnscaled[100]; // create string for file name
       sprintf(nameJacUnscaled, "jacUnscaled%i.mm", countScale);
-      Tpetra_MatrixMarket_Writer::writeSparseFile(nameJacUnscaled, jacT);
+      Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile(nameJacUnscaled, jacT);
       if (fT != Teuchos::null) {
         char nameResUnscaled[100]; // create string for file name
         sprintf(nameResUnscaled, "resUnscaled%i.mm", countScale);
-        Tpetra_MatrixMarket_Writer::writeDenseFile(nameResUnscaled, fT);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(nameResUnscaled, fT);
       }
 #endif
       // set the scaling
@@ -1778,15 +1779,15 @@ void Albany::Application::computeGlobalJacobianImplT(
 #ifdef WRITE_TO_MATRIX_MARKET
       char nameJacScaled[100]; // create string for file name
       sprintf(nameJacScaled, "jacScaled%i.mm", countScale);
-      Tpetra_MatrixMarket_Writer::writeSparseFile(nameJacScaled, jacT);
+      Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile(nameJacScaled, jacT);
       if (fT != Teuchos::null) {
         char nameResScaled[100]; // create string for file name
         sprintf(nameResScaled, "resScaled%i.mm", countScale);
-        Tpetra_MatrixMarket_Writer::writeDenseFile(nameResScaled, fT);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(nameResScaled, fT);
       }
       char nameScale[100]; // create string for file name
       sprintf(nameScale, "scale%i.mm", countScale);
-      Tpetra_MatrixMarket_Writer::writeDenseFile(nameScale, scaleVec_);
+      Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(nameScale, scaleVec_);
 #endif
       countScale++;
     }
@@ -1821,7 +1822,7 @@ void Albany::Application::computeGlobalJacobianImplT(
         sprintf(nameScale, "scale%i.mm", countScale);
       }
       else {
-        Tpetra_MatrixMarket_Writer::writeDenseFile(nameScale, scaleVec_);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(nameScale, scaleVec_);
         // create serial map that puts the whole solution on processor 0
         int numMyElements = (scaleVec_->getMap()->getComm()->getRank() == 0)
                                 ? scaleVec_->getMap()->getGlobalNumElements()
@@ -1837,7 +1838,7 @@ void Albany::Application::computeGlobalJacobianImplT(
             Teuchos::rcp(new Tpetra_Vector(serial_map));
         scale_serial->doImport(*scaleVec_, *importOperator, Tpetra::INSERT);
         sprintf(nameScale, "scaleSerial%i.mm", countScale);
-        Tpetra_MatrixMarket_Writer::writeDenseFile(nameScale, scale_serial);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(nameScale, scale_serial);
       }
 #endif
       countScale++;
@@ -2275,13 +2276,13 @@ void Albany::Application::computeGlobalJacobianT(
     if (writeToMatrixMarketJac ==
         -1) { // write jacobian to MatrixMarket every time it arises
       sprintf(name, "jac%i.mm", countJac);
-      Tpetra_MatrixMarket_Writer::writeSparseFile(name,
+      Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile(name,
                                                   Teuchos::rcpFromRef(jacT));
     } else {
       if (countJac ==
           writeToMatrixMarketJac) { // write jacobian only at requested count#
         sprintf(name, "jac%i.mm", countJac);
-        Tpetra_MatrixMarket_Writer::writeSparseFile(name,
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile(name,
                                                     Teuchos::rcpFromRef(jacT));
       }
     }

--- a/src/Albany_CommTypes.hpp
+++ b/src/Albany_CommTypes.hpp
@@ -1,0 +1,31 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_COMM_TYPES_HPP
+#define ALBANY_COMM_TYPES_HPP
+
+// Get all Albany configuration macros
+#include "Albany_config.h"
+
+// Get Teuchos Comm type
+#include "Teuchos_DefaultComm.hpp"
+
+#ifdef ALBANY_MPI
+  using Albany_MPI_Comm = MPI_Comm;
+
+  #define Albany_MPI_COMM_WORLD MPI_COMM_WORLD
+  #define Albany_MPI_COMM_NULL MPI_COMM_NULL
+#else
+  using Albany_MPI_Comm = int;
+
+  #define Albany_MPI_COMM_WORLD 0  // This is compatible with Dakota
+  #define Albany_MPI_COMM_NULL 99
+#endif
+
+// Teuchos comm typedef
+typedef Teuchos::Comm<int>  Teuchos_Comm;
+
+#endif // ALBANY_COMM_TYPES_HPP

--- a/src/Albany_DataTypes.hpp
+++ b/src/Albany_DataTypes.hpp
@@ -4,180 +4,29 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#ifndef PHAL_DATATYPES
-#define PHAL_DATATYPES
+#ifndef ALBANY_DATA_TYPES_HPP
+#define ALBANY_DATA_TYPES_HPP
 
 // Get all Albany configuration macros
 #include "Albany_config.h"
 
-#ifdef ALBANY_MPI
-  #define Albany_MPI_Comm MPI_Comm
-  #define Albany_MPI_COMM_WORLD MPI_COMM_WORLD
-  #define Albany_MPI_COMM_NULL MPI_COMM_NULL
-  #if defined(ALBANY_EPETRA)
-    #include "Epetra_MpiComm.h"
-  #endif
-  #include "Teuchos_DefaultMpiComm.hpp"
-#else
-  #define Albany_MPI_Comm int
-  #define Albany_MPI_COMM_WORLD 0  // This is compatible with Dakota
-  #define Albany_MPI_COMM_NULL 99
-  #if defined(ALBANY_EPETRA)
-    #include "Epetra_SerialComm.h"
-  #endif
-  #include "Teuchos_DefaultSerialComm.hpp"
-#endif
+// Get scalar and ordinal types
+#include "Albany_ScalarOrdinalTypes.hpp"
 
-//! Data Type Definitions that span the code.
+// Get all Tpetra types
+#include "Albany_TpetraTypes.hpp"
 
-// Include all of our AD types
-#include "Sacado.hpp"
-#include "Sacado_MathFunctions.hpp"
-#include "Sacado_ELRFad_DFad.hpp"
-#include "Sacado_ELRCacheFad_DFad.hpp"
-#include "Sacado_Fad_DFad.hpp"
-#include "Sacado_Fad_SLFad.hpp"
-#include "Sacado_ELRFad_SLFad.hpp"
-#include "Sacado_ELRFad_SFad.hpp"
-#include "Sacado_CacheFad_DFad.hpp"
-#include "Phalanx_KokkosDeviceTypes.hpp"
+// Get all Sacado types (and helpers)
+#include "Albany_SacadoTypes.hpp"
 
-#include "TpetraCore_config.h"
+// Get all Thyra types
+#include "Albany_ThyraTypes.hpp"
 
-#ifndef HAVE_TPETRA_INST_DOUBLE
-#error "Albany needs Tpetra to enable double as a Scalar type"
-#endif
-typedef double RealType;
+// Get the Thyra-Tpetra converter
+#include "Albany_TpetraThyraTypes.hpp"
 
-// Switch between dynamic and static FAD types
-#ifdef ALBANY_FAST_FELIX
-  // Code templated on data type need to know if FadType and TanFadType
-  // are the same or different typdefs
-#define ALBANY_FADTYPE_NOTEQUAL_TANFADTYPE
-  typedef Sacado::Fad::SLFad<RealType, ALBANY_SLFAD_SIZE> FadType;
-#else
-#define ALBANY_SFAD_SIZE 300
-  typedef Sacado::Fad::DFad<RealType> FadType;
-#endif
-
-typedef Sacado::Fad::DFad<RealType> TanFadType;
-
-//Tpetra includes
-#include "Teuchos_DefaultComm.hpp"
-#include "Teuchos_ArrayView.hpp"
-#include "Tpetra_DefaultPlatform.hpp"
-#include "Tpetra_Map.hpp"
-#include "Tpetra_CrsGraph.hpp"
-#include "Tpetra_CrsMatrix.hpp"
-#include "Tpetra_DistObject.hpp"
-#include "Tpetra_Operator.hpp"
-#include "Tpetra_MultiVector.hpp"
-#include "MatrixMarket_Tpetra.hpp"
-#include "Thyra_TpetraThyraWrappers.hpp"
-#include "MatrixMarket_Tpetra.hpp"
-#include "Tpetra_RowMatrixTransposer.hpp"
-
-//Kokkos includes
-#include "Phalanx_KokkosDeviceTypes.hpp"
-
-//Tpetra typedefs
-typedef RealType                                             ST;
-typedef std::int64_t                                         GO;
-typedef std::int32_t                                         LO;
-typedef Kokkos::Compat::KokkosDeviceWrapperNode<PHX::Device> KokkosNode;
-
-typedef int Tpetra_LO;
-#if defined( HAVE_TPETRA_INST_INT_LONG_LONG )
-typedef long long Tpetra_GO;
-#elif defined( HAVE_TPETRA_INST_INT_LONG )
-static_assert(sizeof(long) == sizeof(GO),
-    "Tpetra's biggest enabled GlobalOrdinal is long but thats not 64 bit");
-typedef long Tpetra_GO;
-#elif defined( HAVE_TPETRA_INST_INT_UNSIGNED_LONG )
-static_assert(sizeof(unsigned long) == sizeof(GO),
-    "Tpetra's biggest enabled GlobalOrdinal is unsigned long but thats not 64 bit");
-typedef unsigned long Tpetra_GO;
-#else
-#error "Albany needs a 64-bit GlobalOrdinal enabled in Tpetra"
-#endif
-
-typedef Teuchos::Comm<int>                                            Teuchos_Comm;
-typedef Tpetra::Map<Tpetra_LO, Tpetra_GO, KokkosNode>                 Tpetra_Map;
-typedef Tpetra::Details::LocalMap<Tpetra_LO, Tpetra_GO, KokkosNode>   Tpetra_LocalMap;
-typedef Tpetra::Export<Tpetra_LO, Tpetra_GO, KokkosNode>              Tpetra_Export;
-typedef Tpetra::Import<Tpetra_LO, Tpetra_GO, KokkosNode>              Tpetra_Import;
-typedef Tpetra::CrsGraph<Tpetra_LO, Tpetra_GO, KokkosNode>            Tpetra_CrsGraph;
-typedef Tpetra::CrsMatrix<ST, Tpetra_LO, Tpetra_GO, KokkosNode>       Tpetra_CrsMatrix;
-typedef Tpetra::RowMatrix<ST, Tpetra_LO, Tpetra_GO, KokkosNode>       Tpetra_RowMatrix;
-typedef Tpetra::Operator<ST, Tpetra_LO, Tpetra_GO, KokkosNode>        Tpetra_Operator;
-typedef Tpetra::Vector<ST, Tpetra_LO, Tpetra_GO, KokkosNode>          Tpetra_Vector;
-typedef Tpetra::MultiVector<ST, Tpetra_LO, Tpetra_GO, KokkosNode>     Tpetra_MultiVector;
-typedef Thyra::TpetraOperatorVectorExtraction<
-    ST, Tpetra_LO, Tpetra_GO, KokkosNode> ConverterT;
-typedef Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>                Tpetra_MatrixMarket_Writer;
-typedef Thyra::TpetraVector<ST,Tpetra_LO,Tpetra_GO,KokkosNode>        ThyraVector;
-typedef Thyra::TpetraMultiVector<ST,Tpetra_LO,Tpetra_GO,KokkosNode>   ThyraMultiVector;
-typedef Tpetra::RowMatrixTransposer<
-    ST, Tpetra_LO, Tpetra_GO, KokkosNode >                            Tpetra_RowMatrixTransposer;
-
-// Include ScalarParameterLibrary to specialize its traits
-#include "Sacado_ScalarParameterLibrary.hpp"
-#include "Sacado_ScalarParameterVector.hpp"
-
-// ******************************************************************
-// Definition of Sacado::ParameterLibrary traits
-// ******************************************************************
-struct SPL_Traits {
-  template <class T> struct apply {
-    typedef typename T::ScalarT type;
-  };
-};
-
-// Synonym for the ScalarParameterLibrary/Vector on our traits
-typedef Sacado::ScalarParameterLibrary<SPL_Traits> ParamLib;
-typedef Sacado::ScalarParameterVector<SPL_Traits> ParamVec;
-
-namespace Albany {
-
-  // Function to get the underlying value out of a scalar type
-  template <typename T>
-  typename Sacado::ScalarType<T>::type
-  KOKKOS_INLINE_FUNCTION
-  ADValue(const T& x) { return Sacado::ScalarValue<T>::eval(x); }
-
-  // Function to convert a ScalarType to a different one. This is used to convert
-  // a ScalarT to a ParamScalarT.
-  // Note, for all Evaluation types but one, ScalarT and ParamScalarT are the same,
-  // and for those we want to keep the Fad derivatives (if any).
-  // The only exception can be Jacobian (if mesh/param do not depend on solution),
-  // where ParamScalarT=RealType and ScalarT=FadType.
-  // Notice also that if the two scalar types are different, the conversion works
-  // only if the target type has a constructor from the source type.
-  template<typename ToST,typename FromST>
-  struct ScalarConversionHelper
-  {
-    static typename std::enable_if<std::is_constructible<ToST,FromST>::value,ToST>::type
-    apply (const FromST& x)
-    {
-      return ToST(x);
-    }
-  };
-
-  template<typename FromST>
-  struct ScalarConversionHelper<typename Sacado::ScalarType<FromST>::type,FromST>
-  {
-    static typename Sacado::ScalarType<FromST>::type apply (const FromST& x)
-    {
-      return ADValue(x);
-    }
-  };
-
-  template<typename ToST,typename FromST>
-  ToST convertScalar (const FromST& x)
-  {
-    return ScalarConversionHelper<ToST,FromST>::apply(x);
-  }
-}
+// Get all comm types
+#include "Albany_CommTypes.hpp"
 
 // Code macros to support deprecated warnings
 #ifdef ALBANY_ENABLE_DEPRECATED
@@ -188,4 +37,4 @@ namespace Albany {
 #  endif
 #endif
 
-#endif
+#endif // ALBANY_DATA_TYPES_HPP

--- a/src/Albany_ModelEvaluatorT.cpp
+++ b/src/Albany_ModelEvaluatorT.cpp
@@ -26,6 +26,7 @@ static int mm_counter_jac = 0;
 // for some applications.  Uncomment the following line to turn on.
 //#define WRITE_MASS_MATRIX_TO_MM_FILE
 #ifdef WRITE_MASS_MATRIX_TO_MM_FILE
+#include "MatrixMarket_Tpetra.hpp"
 #include "TpetraExt_MMHelpers.hpp"
 #endif
 
@@ -518,7 +519,6 @@ Albany::ModelEvaluatorT::create_W_prec() const
   Teuchos::RCP<Tpetra_Operator> Extra_W_crs_op =
       Teuchos::nonnull(create_W()) ? ConverterT::getTpetraOperator(create_W()) :
                                      Teuchos::null;
-
   Extra_W_crs =
       Teuchos::rcp_dynamic_cast<Tpetra_CrsMatrix>(Extra_W_crs_op, true);
 
@@ -904,10 +904,10 @@ Albany::ModelEvaluatorT::evalModelImpl(
         sacado_param_vec,
         ftmp.get(),
         *Mass_crs);
-    Tpetra_MatrixMarket_Writer::writeSparseFile("mass.mm", Mass_crs);
-    Tpetra_MatrixMarket_Writer::writeMapFile(
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile("mass.mm", Mass_crs);
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile(
         "rowmap.mm", *Mass_crs->getRowMap());
-    Tpetra_MatrixMarket_Writer::writeMapFile(
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile(
         "colmap.mm", *Mass_crs->getColMap());
 #endif
   }

--- a/src/Albany_PiroObserverT.cpp
+++ b/src/Albany_PiroObserverT.cpp
@@ -15,6 +15,7 @@
 
 //#define DEBUG_OUTPUT
 #ifdef DEBUG_OUTPUT
+#include "MatrixMarket_Tpetra.hpp"
 int ah; 
 #endif
 
@@ -177,9 +178,9 @@ Albany::PiroObserverT::observeSolutionImpl(
   std::cout << "IKT observing solution time = " << defaultStamp << std::endl; 
   char name[100];  //create string for file name
   sprintf(name, "solution%i.mm", ah);
-  Tpetra_MatrixMarket_Writer::writeDenseFile(name, solution_tpetra);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(name, solution_tpetra);
   sprintf(name, "solution_dot%i.mm", ah);
-  Tpetra_MatrixMarket_Writer::writeDenseFile(name, solution_dot_tpetra);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(name, solution_dot_tpetra);
 #endif
   this->observeTpetraSolutionImpl(
       *solution_tpetra,

--- a/src/Albany_SacadoTypes.hpp
+++ b/src/Albany_SacadoTypes.hpp
@@ -1,0 +1,101 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_SACADO_TYPES_HPP
+#define ALBANY_SACADO_TYPES_HPP
+
+// Get all Albany configuration macros
+#include "Albany_config.h"
+
+// Get Albany's RealType
+#include "Albany_ScalarOrdinalTypes.hpp"
+
+// Include all of our AD types
+#include "Sacado.hpp"
+#include "Sacado_MathFunctions.hpp"
+#include "Sacado_ELRFad_DFad.hpp"
+#include "Sacado_ELRCacheFad_DFad.hpp"
+#include "Sacado_Fad_DFad.hpp"
+#include "Sacado_Fad_SLFad.hpp"
+#include "Sacado_ELRFad_SLFad.hpp"
+#include "Sacado_ELRFad_SFad.hpp"
+#include "Sacado_CacheFad_DFad.hpp"
+
+// Include ScalarParameterLibrary to specialize its traits
+#include "Sacado_ScalarParameterLibrary.hpp"
+#include "Sacado_ScalarParameterVector.hpp"
+
+// ******************************************************************
+// Definition of Sacado::ParameterLibrary traits
+// ******************************************************************
+
+// Switch between dynamic and static FAD types
+#ifdef ALBANY_FAST_FELIX
+  // Code templated on data type need to know if FadType and TanFadType
+  // are the same or different typdefs
+#define ALBANY_FADTYPE_NOTEQUAL_TANFADTYPE
+  typedef Sacado::Fad::SLFad<RealType, ALBANY_SLFAD_SIZE> FadType;
+#else
+#define ALBANY_SFAD_SIZE 300
+  typedef Sacado::Fad::DFad<RealType> FadType;
+#endif
+
+typedef Sacado::Fad::DFad<RealType> TanFadType;
+
+struct SPL_Traits {
+  template <class T> struct apply {
+    typedef typename T::ScalarT type;
+  };
+};
+
+// Synonym for the ScalarParameterLibrary/Vector on our traits
+typedef Sacado::ScalarParameterLibrary<SPL_Traits> ParamLib;
+typedef Sacado::ScalarParameterVector<SPL_Traits> ParamVec;
+
+namespace Albany
+{
+
+  // Function to get the underlying value out of a scalar type
+  template <typename T>
+  typename Sacado::ScalarType<T>::type
+  ADValue(const T& x) { return Sacado::ScalarValue<T>::eval(x); }
+
+  // Function to convert a ScalarType to a different one. This is used to convert
+  // a ScalarT to a ParamScalarT.
+  // Note, for all Evaluation types but one, ScalarT and ParamScalarT are the same,
+  // and for those we want to keep the Fad derivatives (if any).
+  // The only exception can be Jacobian (if mesh/param do not depend on solution),
+  // where ParamScalarT=RealType and ScalarT=FadType.
+  // Notice also that if the two scalar types are different, the conversion works
+  // only if the target type has a constructor from the source type.
+  template<typename ToST,typename FromST>
+  struct ScalarConversionHelper
+  {
+    static typename std::enable_if<std::is_constructible<ToST,FromST>::value,ToST>::type
+    apply (const FromST& x)
+    {
+      return ToST(x);
+    }
+  };
+
+  template<typename FromST>
+  struct ScalarConversionHelper<typename Sacado::ScalarType<FromST>::type,FromST>
+  {
+    static typename Sacado::ScalarType<FromST>::type apply (const FromST& x)
+    {
+      return ADValue(x);
+    }
+  };
+
+  template<typename ToST,typename FromST>
+  ToST convertScalar (const FromST& x)
+  {
+    return ScalarConversionHelper<ToST,FromST>::apply(x);
+  }
+
+} // namespace Albany
+
+#endif // ALBANY_SACADO_TYPES_HPP

--- a/src/Albany_ScalarOrdinalTypes.hpp
+++ b/src/Albany_ScalarOrdinalTypes.hpp
@@ -1,0 +1,17 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_SCALAR_ORDINAL_TYPES_HPP
+#define ALBANY_SCALAR_ORDINAL_TYPES_HPP
+
+#include <cstdint>
+
+typedef double        RealType;
+typedef RealType      ST;
+typedef std::int64_t  GO;
+typedef std::int32_t  LO;
+
+#endif // ALBANY_SCALAR_ORDINAL_TYPES_HPP

--- a/src/Albany_ThyraTypes.hpp
+++ b/src/Albany_ThyraTypes.hpp
@@ -1,0 +1,37 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_THYRA_TYPES_HPP
+#define ALBANY_THYRA_TYPES_HPP
+
+// Get all Albany configuration macros
+#include "Albany_config.h"
+
+// Get the scalar type
+#include "Albany_ScalarOrdinalTypes.hpp"
+
+// Thyra includes
+#include "Thyra_MultiVectorBase.hpp"
+#include "Thyra_VectorBase.hpp"
+#include "Thyra_VectorSpaceBase.hpp"
+#include "Thyra_ModelEvaluator.hpp"
+#include "Thyra_LinearOpBase.hpp"
+#include "Thyra_LinearOpWithSolveBase.hpp"
+#include "Thyra_LinearOpWithSolveFactoryBase.hpp"
+
+typedef Thyra::VectorSpaceBase<ST>                Thyra_VectorSpace;
+typedef Thyra::MultiVectorBase<ST>                Thyra_MultiVector;
+typedef Thyra::VectorBase<ST>                     Thyra_Vector;
+typedef Thyra::LinearOpBase<ST>                   Thyra_LinearOp;
+typedef Thyra::PreconditionerBase<ST>             Thyra_Preconditioner;
+typedef Thyra::LinearOpWithSolveBase<ST>          Thyra_LOWS;
+typedef Thyra::LinearOpWithSolveFactoryBase<ST>   Thyra_LOWS_Factory;
+
+typedef Thyra::ModelEvaluator<ST>                 Thyra_ModelEvaluator;
+typedef Thyra_ModelEvaluator::InArgs<ST>          Thyra_InArgs;
+typedef Thyra_ModelEvaluator::OutArgs<ST>         Thyra_OutArgs;
+
+#endif // ALBANY_THYRA_TYPES_HPP

--- a/src/Albany_TpetraThyraTypes.hpp
+++ b/src/Albany_TpetraThyraTypes.hpp
@@ -1,0 +1,20 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_TPETRA_THYRA_TYPES_HPP
+#define ALBANY_TPETRA_THYRA_TYPES_HPP
+
+// Get all Albany configuration macros
+#include "Albany_config.h"
+
+// Get the converters
+#include "Thyra_TpetraThyraWrappers.hpp"
+
+typedef Thyra::TpetraOperatorVectorExtraction<ST, Tpetra_LO, Tpetra_GO, KokkosNode>   ConverterT;
+typedef Thyra::TpetraMultiVector<ST,Tpetra_LO,Tpetra_GO,KokkosNode>                   Thyra_TpetraMultiVector;
+typedef Thyra::TpetraVector<ST,Tpetra_LO,Tpetra_GO,KokkosNode>                        Thyra_TpetraVector;
+
+#endif // ALBANY_TPETRA_THYRA_TYPES_HPP

--- a/src/Albany_TpetraTypes.hpp
+++ b/src/Albany_TpetraTypes.hpp
@@ -1,0 +1,62 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_TPETRA_TYPES_HPP
+#define ALBANY_TPETRA_TYPES_HPP
+
+// Get all Albany configuration macros
+#include "Albany_config.h"
+
+// Get the scalar and ordinal types
+#include "Albany_ScalarOrdinalTypes.hpp"
+
+// Tpetra includes
+#include "TpetraCore_config.h"
+#include "Tpetra_DefaultPlatform.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_CrsGraph.hpp"
+#include "Tpetra_CrsMatrix.hpp"
+#include "Tpetra_DistObject.hpp"
+#include "Tpetra_Operator.hpp"
+#include "Tpetra_MultiVector.hpp"
+
+// Phalanx determines the Kokkos node we use for Tpetra types
+#include "Phalanx_KokkosDeviceTypes.hpp"
+
+#ifndef HAVE_TPETRA_INST_DOUBLE
+#error "Albany needs Tpetra to enable double as a Scalar type"
+#endif
+
+typedef int Tpetra_LO;
+#if defined( HAVE_TPETRA_INST_INT_LONG_LONG )
+typedef long long Tpetra_GO;
+#elif defined( HAVE_TPETRA_INST_INT_LONG )
+static_assert(sizeof(long) == sizeof(GO),
+    "Tpetra's biggest enabled GlobalOrdinal is long but thats not 64 bit");
+typedef long Tpetra_GO;
+#elif defined( HAVE_TPETRA_INST_INT_UNSIGNED_LONG )
+static_assert(sizeof(unsigned long) == sizeof(GO),
+    "Tpetra's biggest enabled GlobalOrdinal is unsigned long but thats not 64 bit");
+typedef unsigned long Tpetra_GO;
+#else
+#error "Albany needs a 64-bit GlobalOrdinal enabled in Tpetra"
+#endif
+
+// The Kokkos node is determined from the Phalanx Device
+typedef Kokkos::Compat::KokkosDeviceWrapperNode<PHX::Device>          KokkosNode;
+
+typedef Tpetra::Map<Tpetra_LO, Tpetra_GO, KokkosNode>                 Tpetra_Map;
+typedef Tpetra::Details::LocalMap<Tpetra_LO, Tpetra_GO, KokkosNode>   Tpetra_LocalMap;
+typedef Tpetra::Export<Tpetra_LO, Tpetra_GO, KokkosNode>              Tpetra_Export;
+typedef Tpetra::Import<Tpetra_LO, Tpetra_GO, KokkosNode>              Tpetra_Import;
+typedef Tpetra::CrsGraph<Tpetra_LO, Tpetra_GO, KokkosNode>            Tpetra_CrsGraph;
+typedef Tpetra::CrsMatrix<ST, Tpetra_LO, Tpetra_GO, KokkosNode>       Tpetra_CrsMatrix;
+typedef Tpetra::RowMatrix<ST, Tpetra_LO, Tpetra_GO, KokkosNode>       Tpetra_RowMatrix;
+typedef Tpetra::Operator<ST, Tpetra_LO, Tpetra_GO, KokkosNode>        Tpetra_Operator;
+typedef Tpetra::Vector<ST, Tpetra_LO, Tpetra_GO, KokkosNode>          Tpetra_Vector;
+typedef Tpetra::MultiVector<ST, Tpetra_LO, Tpetra_GO, KokkosNode>     Tpetra_MultiVector;
+
+#endif // ALBANY_TPETRA_TYPES_HPP

--- a/src/Albany_TpetraTypes.hpp
+++ b/src/Albany_TpetraTypes.hpp
@@ -13,6 +13,9 @@
 // Get the scalar and ordinal types
 #include "Albany_ScalarOrdinalTypes.hpp"
 
+// Phalanx determines the Kokkos node we use for Tpetra types
+#include "Phalanx_KokkosDeviceTypes.hpp"
+
 // Tpetra includes
 #include "TpetraCore_config.h"
 #include "Tpetra_DefaultPlatform.hpp"
@@ -22,9 +25,6 @@
 #include "Tpetra_DistObject.hpp"
 #include "Tpetra_Operator.hpp"
 #include "Tpetra_MultiVector.hpp"
-
-// Phalanx determines the Kokkos node we use for Tpetra types
-#include "Phalanx_KokkosDeviceTypes.hpp"
 
 #ifndef HAVE_TPETRA_INST_DOUBLE
 #error "Albany needs Tpetra to enable double as a Scalar type"
@@ -49,7 +49,6 @@ typedef unsigned long Tpetra_GO;
 typedef Kokkos::Compat::KokkosDeviceWrapperNode<PHX::Device>          KokkosNode;
 
 typedef Tpetra::Map<Tpetra_LO, Tpetra_GO, KokkosNode>                 Tpetra_Map;
-typedef Tpetra::Details::LocalMap<Tpetra_LO, Tpetra_GO, KokkosNode>   Tpetra_LocalMap;
 typedef Tpetra::Export<Tpetra_LO, Tpetra_GO, KokkosNode>              Tpetra_Export;
 typedef Tpetra::Import<Tpetra_LO, Tpetra_GO, KokkosNode>              Tpetra_Import;
 typedef Tpetra::CrsGraph<Tpetra_LO, Tpetra_GO, KokkosNode>            Tpetra_CrsGraph;

--- a/src/Albany_Utils.cpp
+++ b/src/Albany_Utils.cpp
@@ -5,6 +5,17 @@
 //*****************************************************************//
 
 #include "Albany_Utils.hpp"
+
+// Include the concrete Epetra Comm's, if needed
+#if defined(ALBANY_EPETRA)
+  #ifdef ALBANY_MPI
+    #include "Epetra_MpiComm.h"
+  #else
+    #include "Epetra_SerialComm.h"
+  #endif
+#endif
+
+#include "MatrixMarket_Tpetra.hpp"
 #include "Teuchos_TestForException.hpp"
 #include <cstdlib>
 #include <stdexcept>
@@ -42,7 +53,7 @@
         }
       }
     }
-    //Tpetra_MatrixMarket_Writer::writeSparseFile("prec.mm", matrix);
+    //Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile("prec.mm", matrix);
   }
 
   void 
@@ -301,7 +312,7 @@
     std::string const &
     filename = oss.str();
 
-    Tpetra_MatrixMarket_Writer::writeDenseFile(filename, x);
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(filename, x);
 
     return;
   }
@@ -331,7 +342,7 @@
     std::string const &
     filename = oss.str();
 
-    Tpetra_MatrixMarket_Writer::writeSparseFile(filename, A);
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile(filename, A);
 
     return;
   }

--- a/src/Albany_Utils.hpp
+++ b/src/Albany_Utils.hpp
@@ -18,6 +18,10 @@
 #include "Albany_DataTypes.hpp"
 #include "Teuchos_RCP.hpp"
 
+#if defined(ALBANY_EPETRA)
+#include "Epetra_Comm.h"
+#endif
+
 // Checks if the previous Kokkos::Cuda kernel has failed
 #ifdef ALBANY_CUDA_ERROR_CHECK
 #define cudaCheckError() \

--- a/src/FELIX/interface_with_cism/felix_driver.cpp
+++ b/src/FELIX/interface_with_cism/felix_driver.cpp
@@ -55,6 +55,8 @@
 #ifdef CISM_USE_EPETRA
 #include "EpetraExt_MultiVectorOut.h"
 #include "EpetraExt_BlockMapOut.h"
+#else
+#include "MatrixMarket_Tpetra.hpp"
 #endif
 #endif
 
@@ -807,10 +809,10 @@ void felix_driver_run(FelixToGlimmer * ftg_ptr, double& cur_time_yr, double time
     EpetraExt::BlockMapToMatrixMarketFile("overlap_map.mm", overlapMap);
     EpetraExt::MultiVectorToMatrixMarketFile("solution.mm", *albanyApp->getDiscretization()->getSolutionField());
 #else
-    Tpetra_MatrixMarket_Writer::writeMapFile("node_map.mm", *node_map);
-    Tpetra_MatrixMarket_Writer::writeMapFile("map.mm", *ownedMap);
-    Tpetra_MatrixMarket_Writer::writeMapFile("overlap_map.mm", *overlapMap);
-    Tpetra_MatrixMarket_Writer::writeDenseFile("solution.mm", albanyApp->getDiscretization()->getSolutionFieldT());
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile("node_map.mm", *node_map);
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile("map.mm", *ownedMap);
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile("overlap_map.mm", *overlapMap);
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("solution.mm", albanyApp->getDiscretization()->getSolutionFieldT());
 #endif
 #endif
 

--- a/src/LCM/evaluators/responses/ProjectIPtoNodalField_Def.hpp
+++ b/src/LCM/evaluators/responses/ProjectIPtoNodalField_Def.hpp
@@ -10,10 +10,6 @@
 #include <Teuchos_TestForException.hpp>
 #include <fstream>
 
-#include <Thyra_LinearOpWithSolveBase.hpp>
-#include <Thyra_TpetraLinearOp.hpp>
-#include <Thyra_TpetraMultiVector.hpp>
-#include <Thyra_VectorBase.hpp>
 #ifdef ALBANY_IFPACK2
 #include <Thyra_Ifpack2PreconditionerFactory.hpp>
 #endif

--- a/src/LCM/solvers/Schwarz_Coupled.cpp
+++ b/src/LCM/solvers/Schwarz_Coupled.cpp
@@ -713,7 +713,7 @@ Teuchos::RCP<Thyra::VectorSpaceBase<ST> const>
 SchwarzCoupled::get_g_space(int l) const
 {
   ALBANY_EXPECT(0 <= l && l < num_responses_total_);
-  
+
   return getThyraResponseSpace(l); 
 
   //IKT, 2/2/18: original code which was giving rise to dangling
@@ -946,14 +946,14 @@ evalModelImpl(
 
   for (auto m = 0; m < num_models_; ++m) {
     //Get each Tpetra vector
-    xTs[m] = Teuchos::rcp_dynamic_cast<const ThyraVector>(
+    xTs[m] = Teuchos::rcp_dynamic_cast<const Thyra_TpetraVector>(
         xT->getVectorBlock(m),
         true)->getConstTpetraVector();
   }
   if (x_dotT != Teuchos::null) {
     for (auto m = 0; m < num_models_; ++m) {
       //Get each Tpetra vector
-      x_dotTs[m] = Teuchos::rcp_dynamic_cast<const ThyraVector>(
+      x_dotTs[m] = Teuchos::rcp_dynamic_cast<const Thyra_TpetraVector>(
           x_dotT->getVectorBlock(m),
           true)->getConstTpetraVector();
     }
@@ -1003,7 +1003,7 @@ evalModelImpl(
       // only the first vector in the Thyra Product MultiVec is correct.
       // Why...?
       Teuchos::RCP<Tpetra_Vector const>
-      pTm = Teuchos::rcp_dynamic_cast<const ThyraVector>(
+      pTm = Teuchos::rcp_dynamic_cast<const Thyra_TpetraVector>(
           pT->getVectorBlock(0), true)->getConstTpetraVector();
 
       Teuchos::ArrayRCP<ST const> pTm_constView = pTm->get1dView();
@@ -1026,7 +1026,7 @@ evalModelImpl(
   if (fT_out != Teuchos::null) {
     for (auto m = 0; m < num_models_; ++m) {
       //Get each Tpetra vector
-      fTs_out[m] = Teuchos::rcp_dynamic_cast<ThyraVector>(
+      fTs_out[m] = Teuchos::rcp_dynamic_cast<Thyra_TpetraVector>(
           fT_out->getNonconstVectorBlock(m),
           true)->getTpetraVector();
     }
@@ -1119,7 +1119,7 @@ evalModelImpl(
           //doesn't overwrite the real residual.
           Teuchos::RCP<Tpetra_Vector> fTtemp;
           if (fT_out != Teuchos::null) {
-            fTtemp = Teuchos::rcp_dynamic_cast<ThyraVector>(
+            fTtemp = Teuchos::rcp_dynamic_cast<Thyra_TpetraVector>(
                 fT_out->getNonconstVectorBlock(m),
                 true)->getTpetraVector();
           }
@@ -1158,7 +1158,7 @@ evalModelImpl(
           //doesn't overwrite the real residual.
           Teuchos::RCP<Tpetra_Vector> fTtemp;
           if (fT_out != Teuchos::null) {
-            fTtemp = Teuchos::rcp_dynamic_cast<ThyraVector>(
+            fTtemp = Teuchos::rcp_dynamic_cast<Thyra_TpetraVector>(
                 fT_out->getNonconstVectorBlock(m),
                 true)->getTpetraVector();
           }
@@ -1268,7 +1268,7 @@ evalModelImpl(
       for (auto m = 0; m < num_models_; ++m) {
         //Get each Tpetra vector
         Teuchos::RCP<Tpetra_Vector>
-        gT_out_m = Teuchos::rcp_dynamic_cast<ThyraVector>(
+        gT_out_m = Teuchos::rcp_dynamic_cast<Thyra_TpetraVector>(
             gT_out->getNonconstVectorBlock(m),
             true)->getTpetraVector();
 

--- a/src/LCM/solvers/Schwarz_CoupledJacobian.cpp
+++ b/src/LCM/solvers/Schwarz_CoupledJacobian.cpp
@@ -14,6 +14,7 @@
 //#define WRITE_TO_MATRIX_MARKET
 
 #ifdef WRITE_TO_MATRIX_MARKET
+#include "MatrixMarket_Tpetra.hpp"
 static int
 mm_counter = 0;
 #endif // WRITE_TO_MATRIX_MARKET
@@ -55,7 +56,7 @@ const
 
   for (auto i = 0; i < block_dim; ++i) {
     sprintf(name, "Jac%02d_%04d.mm", i, mm_counter);
-    Tpetra_MatrixMarket_Writer::writeSparseFile(name, jacs[i]);
+    Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile(name, jacs[i]);
   }
   mm_counter++;
 #endif // WRITE_TO_MATRIX_MARKET

--- a/src/LCM/solvers/Schwarz_PiroObserver.cpp
+++ b/src/LCM/solvers/Schwarz_PiroObserver.cpp
@@ -76,7 +76,7 @@ tpetraFromThyra(Thyra::VectorBase<double> const & v, int n_models)
 
   for (int m = 0; m < n_models; ++m) {
     //Get each Tpetra vector
-    vs[m] = Teuchos::rcp_dynamic_cast<const ThyraVector>(
+    vs[m] = Teuchos::rcp_dynamic_cast<const Thyra_TpetraVector>(
         v_nonowning_rcp->getVectorBlock(m), true)->getConstTpetraVector();
   }
   return vs;

--- a/src/MOR/MOR_ReducedOrderModelEvaluator.cpp
+++ b/src/MOR/MOR_ReducedOrderModelEvaluator.cpp
@@ -22,6 +22,7 @@
 #include <Tpetra_MultiVectorFiller.hpp>
 #include "Petra_Converters.hpp"
 #include "EpetraExt_RowMatrixOut.h"
+#include "MatrixMarket_Tpetra.hpp"
 
 // for mkdir
 #include <sys/stat.h>
@@ -683,14 +684,14 @@ void ReducedOrderModelEvaluator::printCRSMatrix(std::string filename, const Teuc
 	parOut("ReducedOrderModelEvaluator::evalModel writing file named: " + full_filename);
 	TEUCHOS_TEST_FOR_EXCEPT(CRSM == Teuchos::null)
 	Teuchos::RCP<Tpetra_CrsMatrix> CRSM_T = Petra::EpetraCrsMatrix_To_TpetraCrsMatrix(*CRSM, app_->getComm());
-	Tpetra_MatrixMarket_Writer::writeSparseFile(full_filename, CRSM_T);
+	Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile(full_filename, CRSM_T);
 	/*
-	Tpetra_MatrixMarket_Writer::writeSparseFile(full_filename, CRSM_T, true);
+	Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile(full_filename, CRSM_T, true);
 
 	std::string mystr = outdir_ + filename + "_Rmap" + std::to_string(index) + ".mm";
-	Tpetra_MatrixMarket_Writer::writeMapFile(mystr, *CRSM_T->getRowMap());
+	Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile(mystr, *CRSM_T->getRowMap());
 	std::string mystr2 = outdir_ + filename + "_Cmap" + std::to_string(index) + ".mm";
-	Tpetra_MatrixMarket_Writer::writeMapFile(mystr2, *CRSM_T->getColMap());
+	Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile(mystr2, *CRSM_T->getColMap());
 	*/
 }
 
@@ -758,18 +759,18 @@ void ReducedOrderModelEvaluator::printMultiVectorT(std::string filename, const T
 	if (isDist)
 	{
 		Teuchos::RCP<Tpetra_MultiVector> MV_serial = serialVector<Tpetra_MultiVector>(MV);
-		Tpetra_MatrixMarket_Writer::writeDenseFile(full_filename, MV_serial);
+		Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(full_filename, MV_serial);
 	}
 	else
 	{
-		Tpetra_MatrixMarket_Writer::writeDenseFile(full_filename, MV);
+		Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(full_filename, MV);
 	}
 
 	/*
 	std::string mystr = outdir_ + filename + "_map" + std::to_string(index) + ".mm";
-	Tpetra_MatrixMarket_Writer::writeMapFile(mystr, *MV->getMap());
+	Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile(mystr, *MV->getMap());
 	//std::string mystr2 = outdir_ + filename + "_serial_map" + std::to_string(index) + ".mm";
-	//Tpetra_MatrixMarket_Writer::writeMapFile(mystr2, *MV_serial->getMap());
+	//Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile(mystr2, *MV_serial->getMap());
 	*/
 }
 
@@ -1573,7 +1574,7 @@ void ReducedOrderModelEvaluator::evalModel(const InArgs &inArgs, const OutArgs &
 			EpetraExt::RowMatrixToMatrixMarketFile(full_filename.c_str(), *W_r);
 			//EpetraExt::BlockMapToMatrixMarketFile("JEr_pre_Rmap.mm", W_r->RowMap());
 			//EpetraExt::BlockMapToMatrixMarketFile("JEr_pre_Cmap.mm", W_r->ColMap());
-			//printCRSMatrix("Jr_pre", W_r, count_jacr_pl); // Tpetra_MatrixMarket_Writer::writeSparseFile fails here because the Jacobian is locally replicated (see issue #1021 on GitHub)
+			//printCRSMatrix("Jr_pre", W_r, count_jacr_pl); // Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile fails here because the Jacobian is locally replicated (see issue #1021 on GitHub)
 		}
 
 		DBC_ROM_jac(inArgs,outArgs,SDBC);
@@ -1588,7 +1589,7 @@ void ReducedOrderModelEvaluator::evalModel(const InArgs &inArgs, const OutArgs &
 			EpetraExt::RowMatrixToMatrixMarketFile(full_filename.c_str(), *W_r);
 			//EpetraExt::BlockMapToMatrixMarketFile("JEr_Rmap.mm", W_r->RowMap());
 			//EpetraExt::BlockMapToMatrixMarketFile("JEr_Cmap.mm", W_r->ColMap());
-			//printCRSMatrix("Jr", W_r, count_jacr_pl); // Tpetra_MatrixMarket_Writer::writeSparseFile fails here because the Jacobian is locally replicated (see issue #1021 on GitHub)
+			//printCRSMatrix("Jr", W_r, count_jacr_pl); // Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile fails here because the Jacobian is locally replicated (see issue #1021 on GitHub)
 			count_jacr_pl++;
 		}
 //TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, "we'll just stop here...");

--- a/src/Main_Analysis.cpp
+++ b/src/Main_Analysis.cpp
@@ -9,7 +9,6 @@
 #include "Albany_SolverFactory.hpp"
 #include "Thyra_EpetraModelEvaluator.hpp"
 #include "Piro_PerformAnalysis.hpp"
-#include "Thyra_VectorBase.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_TimeMonitor.hpp"
 #include "Teuchos_VerboseObject.hpp"

--- a/src/Main_AnalysisT.cpp
+++ b/src/Main_AnalysisT.cpp
@@ -8,7 +8,6 @@
 #include "Albany_Utils.hpp"
 #include "Albany_SolverFactory.hpp"
 #include "Piro_PerformAnalysis.hpp"
-#include "Thyra_VectorBase.hpp"
 #include "Teuchos_GlobalMPISession.hpp"
 #include "Teuchos_TimeMonitor.hpp"
 #include "Teuchos_VerboseObject.hpp"

--- a/src/Main_SolveT.cpp
+++ b/src/Main_SolveT.cpp
@@ -22,6 +22,7 @@
 #include "Teuchos_VerboseObject.hpp"
 #include "Thyra_DefaultProductVector.hpp"
 #include "Thyra_DefaultProductVectorSpace.hpp"
+#include "MatrixMarket_Tpetra.hpp"
 
 // Uncomment for run time nan checking
 // This is set in the toplevel CMakeLists.txt file
@@ -485,7 +486,7 @@ main(int argc, char *argv[]) {
           // moment so we cannot
           // allow for different parameters in different models.
           Teuchos::RCP<const Tpetra_Vector> p =
-              Teuchos::rcp_dynamic_cast<const ThyraVector>(
+              Teuchos::rcp_dynamic_cast<const Thyra_TpetraVector>(
                   pT->getVectorBlock(0), true)
                   ->getConstTpetraVector();
           Albany::printTpetraVector(
@@ -578,13 +579,13 @@ main(int argc, char *argv[]) {
         xfinal_serial->doImport(*xfinal, *importOperator, Tpetra::INSERT);
 
         // writing to MatrixMarket file
-        Tpetra_MatrixMarket_Writer::writeDenseFile("xfinal.mm", xfinal_serial);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("xfinal.mm", xfinal_serial);
       }
       if (writeToMatrixMarketDistrSolnMap == true) {
         // writing to MatrixMarket file
-        Tpetra_MatrixMarket_Writer::writeDenseFile(
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(
             "xfinal_distributed.mm", *xfinal);
-        Tpetra_MatrixMarket_Writer::writeMapFile(
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile(
             "xfinal_distributed_map.mm", *xfinal->getMap());
       }
     }

--- a/src/Main_SolveT_Tempus.cpp
+++ b/src/Main_SolveT_Tempus.cpp
@@ -22,6 +22,7 @@
 #include "Teuchos_FancyOStream.hpp"
 #include "Thyra_DefaultProductVector.hpp"
 #include "Thyra_DefaultProductVectorSpace.hpp"
+#include "MatrixMarket_Tpetra.hpp"
 
 #include "Tempus_IntegratorBasic.hpp" 
 #include "Piro_ObserverToTempusIntegrationObserverAdapter.hpp"
@@ -329,12 +330,12 @@ int main(int argc, char *argv[]) {
         Teuchos::RCP<Tpetra_Vector> x_tpetra_serial = Teuchos::rcp(new Tpetra_Vector(serial_map)); 
         x_tpetra_serial->doImport(*x_tpetra, *importOperator, Tpetra::INSERT);
         //writing to MatrixMarket file
-         Tpetra_MatrixMarket_Writer::writeDenseFile("xfinal_tempus.mm", x_tpetra_serial);
+         Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("xfinal_tempus.mm", x_tpetra_serial);
       }
       if (writeToMatrixMarketDistrSolnMap == true) {
         //writing to MatrixMarket file
-        Tpetra_MatrixMarket_Writer::writeDenseFile("xfinal_tempus_distributed.mm", *x_tpetra);
-        Tpetra_MatrixMarket_Writer::writeMapFile("xfinal_tempus_distributed_map.mm", *x_tpetra->getMap());
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("xfinal_tempus_distributed.mm", *x_tpetra);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile("xfinal_tempus_distributed_map.mm", *x_tpetra->getMap());
       }
       *out << "\n Finish Transient Tempus No Piro time integration!\n";
       //End of code to use Tempus to perform time-integration without going through Piro

--- a/src/Petra_Converters.hpp
+++ b/src/Petra_Converters.hpp
@@ -9,6 +9,8 @@
 
 #include "Teuchos_RCP.hpp"
 #include "Albany_DataTypes.hpp"
+
+#include "Epetra_Comm.h"
 #include "Epetra_Vector.h"
 #include "Epetra_CrsGraph.h"
 #include "Epetra_CrsMatrix.h"

--- a/src/Petra_Converters.hpp
+++ b/src/Petra_Converters.hpp
@@ -18,6 +18,8 @@
 #include "Epetra_Import.h"
 #include "Epetra_LocalMap.h"
 
+#include "Kokkos_DefaultNode.hpp"
+
 namespace Petra {
 //TpetraMap_To_EpetraMap: takes in Tpetra::Map object, converts it to its equivalent Epetra_Map object,
 //and returns an RCP pointer to this Epetra_Map

--- a/src/QCAD/QCADT_CoupledPoissonSchrodinger.cpp
+++ b/src/QCAD/QCADT_CoupledPoissonSchrodinger.cpp
@@ -859,14 +859,14 @@ evalModelImpl(
  
    for (int m=0; m < num_models_; ++m) {
     //Get each Tpetra vector 
-    xTs[m] = Teuchos::rcp_dynamic_cast<const ThyraVector>(
+    xTs[m] = Teuchos::rcp_dynamic_cast<const Thyra_TpetraVector>(
         x->getVectorBlock(m),
         true)->getConstTpetraVector();
    }
    if (x_dot != Teuchos::null) {
      for (int m = 0; m < num_models_; ++m) {
         //Get each Tpetra vector 
-        x_dotTs[m] = Teuchos::rcp_dynamic_cast<const ThyraVector>(
+        x_dotTs[m] = Teuchos::rcp_dynamic_cast<const Thyra_TpetraVector>(
             x_dot->getVectorBlock(m),
             true)->getConstTpetraVector();
      }
@@ -889,7 +889,7 @@ evalModelImpl(
     if (pT != Teuchos::null) {
       if(i < num_poisson_param_vecs) {
         //get Poisson parameter vector
-        Teuchos::RCP<Tpetra_Vector const> pT_poisson = Teuchos::rcp_dynamic_cast<const ThyraVector>(
+        Teuchos::RCP<Tpetra_Vector const> pT_poisson = Teuchos::rcp_dynamic_cast<const Thyra_TpetraVector>(
                                           pT->getVectorBlock(0), true)->getConstTpetraVector();
         Teuchos::ArrayRCP<ST const> pT_poisson_constView = pT_poisson->get1dView();
 	for (unsigned int j=0; j<poisson_sacado_param_vec[i].size(); j++) 
@@ -897,7 +897,7 @@ evalModelImpl(
       }
       else {
         //get Schrodinger parameter vector
-        Teuchos::RCP<Tpetra_Vector const> pT_schrodinger = Teuchos::rcp_dynamic_cast<const ThyraVector>(
+        Teuchos::RCP<Tpetra_Vector const> pT_schrodinger = Teuchos::rcp_dynamic_cast<const Thyra_TpetraVector>(
                                           pT->getVectorBlock(1), true)->getConstTpetraVector();
         Teuchos::ArrayRCP<ST const> pT_schrodinger_constView = pT_schrodinger->get1dView();
 	for (unsigned int j=0; j<schrodinger_sacado_param_vec[i-num_poisson_param_vecs].size(); j++)
@@ -972,16 +972,16 @@ evalModelImpl(
 
   if (f_out != Teuchos::null) {
     //First model is Poisson.
-    f_poisson = Teuchos::rcp_dynamic_cast<ThyraVector>(
+    f_poisson = Teuchos::rcp_dynamic_cast<Thyra_TpetraVector>(
         f_out->getNonconstVectorBlock(0),
         true)->getTpetraVector();
     //Next nEigenvals models are Schrodinger
     for (int m=1; m < 1+nEigenvals; ++m) 
-      f_schrodinger_vec[m-1] = Teuchos::rcp_dynamic_cast<ThyraVector>(
+      f_schrodinger_vec[m-1] = Teuchos::rcp_dynamic_cast<Thyra_TpetraVector>(
         f_out->getNonconstVectorBlock(m),
         true)->getTpetraVector().getRawPtr();  
     //Last model is eigenvalue. 
-    f_norm_dist = Teuchos::rcp_dynamic_cast<ThyraVector>(
+    f_norm_dist = Teuchos::rcp_dynamic_cast<Thyra_TpetraVector>(
         f_out->getNonconstVectorBlock(1+nEigenvals), true)->getTpetraVector(); 
     //   (later we sum all procs contributions together and copy into distributed f_norm_dist vector)
     f_norm_local = Teuchos::rcp(new Tpetra_Vector(local_eigenval_map));
@@ -1462,12 +1462,12 @@ evalModelImpl(
     if (g_out != Teuchos::null && !g_computed) {
       //Poisson model:
       Teuchos::RCP<Tpetra_Vector>
-        g_out_poisson = Teuchos::rcp_dynamic_cast<ThyraVector>(
+        g_out_poisson = Teuchos::rcp_dynamic_cast<Thyra_TpetraVector>(
                   g_out->getNonconstVectorBlock(0),
                   true)->getTpetraVector();
       //Schrodinger model:
       Teuchos::RCP<Tpetra_Vector>
-        g_out_schrodinger = Teuchos::rcp_dynamic_cast<ThyraVector>(
+        g_out_schrodinger = Teuchos::rcp_dynamic_cast<Thyra_TpetraVector>(
                   g_out->getNonconstVectorBlock(1),
                   true)->getTpetraVector();
       if(i < poissonApp->getNumResponses()) {

--- a/src/disc/stk/Aeras_SpectralDiscretization.cpp
+++ b/src/disc/stk/Aeras_SpectralDiscretization.cpp
@@ -49,6 +49,8 @@ extern "C"
 #include "Petra_Converters.hpp"
 #endif
 
+#include "MatrixMarket_Tpetra.hpp"
+
 // Albany includes
 #include "Albany_Utils.hpp"
 #include "Albany_NodalGraphUtils.hpp"
@@ -610,10 +612,10 @@ void Aeras::SpectralDiscretization::writeCoordsToMatrixMarket() const
       // Writing of coordinates to MatrixMarket file for Ray
       Teuchos::RCP<Tpetra_Vector> xCoords_serialT = Teuchos::rcp(new Tpetra_Vector(serial_mapT));
       xCoords_serialT->doImport(*xCoordsT, *importOperatorT, Tpetra::INSERT);
-      Tpetra_MatrixMarket_Writer::writeDenseFile("xCoords.mm", xCoords_serialT);
+      Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("xCoords.mm", xCoords_serialT);
     }
     else
-      Tpetra_MatrixMarket_Writer::writeDenseFile("xCoords.mm", xCoordsT);
+      Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("xCoords.mm", xCoordsT);
     if (coordMV->getNumVectors() > 1)
     {
       Teuchos::RCP<Tpetra_Vector> yCoordsT = coordMV->getVector(1);
@@ -621,10 +623,10 @@ void Aeras::SpectralDiscretization::writeCoordsToMatrixMarket() const
       {
         Teuchos::RCP<Tpetra_Vector> yCoords_serialT = Teuchos::rcp(new Tpetra_Vector(serial_mapT));
         yCoords_serialT->doImport(*yCoordsT, *importOperatorT, Tpetra::INSERT);
-        Tpetra_MatrixMarket_Writer::writeDenseFile("yCoords.mm", yCoords_serialT);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("yCoords.mm", yCoords_serialT);
       }
       else
-        Tpetra_MatrixMarket_Writer::writeDenseFile("yCoords.mm", yCoordsT);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("yCoords.mm", yCoordsT);
     }
     if (coordMV->getNumVectors() > 2)
     {
@@ -633,10 +635,10 @@ void Aeras::SpectralDiscretization::writeCoordsToMatrixMarket() const
       {
         Teuchos::RCP<Tpetra_Vector> zCoords_serialT = Teuchos::rcp(new Tpetra_Vector(serial_mapT));
         zCoords_serialT->doImport(*zCoordsT, *importOperatorT, Tpetra::INSERT);
-        Tpetra_MatrixMarket_Writer::writeDenseFile("zCoords.mm", zCoords_serialT);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("zCoords.mm", zCoords_serialT);
       }
       else
-        Tpetra_MatrixMarket_Writer::writeDenseFile("zCoords.mm", zCoordsT);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("zCoords.mm", zCoordsT);
     }
   }
 #endif
@@ -787,7 +789,7 @@ Aeras::SpectralDiscretization::writeSolutionToMeshDatabaseT(
 {
 #ifdef WRITE_TO_MATRIX_MARKET_TO_MM_FILE
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << std::endl;
-  Tpetra_MatrixMarket_Writer::writeDenseFile("solnT.mm", solnT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("solnT.mm", solnT);
 #endif
   // Put solution as Tpetra_Vector into STK Mesh
   if (!overlapped)
@@ -842,7 +844,7 @@ Aeras::SpectralDiscretization::writeSolutionMVToMeshDatabase(
 {
 #ifdef OUTPUT_TO_SCREEN
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << std::endl;
-   Tpetra_MatrixMarket_Writer::writeDenseFile("solnT.mm", solnT);
+   Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("solnT.mm", solnT);
 #endif
   // Put solution as Epetra_Vector into STK Mesh
   if (!overlapped)
@@ -3618,8 +3620,8 @@ Aeras::SpectralDiscretization::updateMesh()
 
 #ifdef WRITE_TO_MATRIX_MARKET_TO_MM_FILE
   //write owned maps to matrix market file for debug
-  Tpetra_MatrixMarket_Writer::writeMapFile("mapT.mm", *mapT);
-  Tpetra_MatrixMarket_Writer::writeMapFile("node_mapT.mm", *node_mapT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile("mapT.mm", *mapT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile("node_mapT.mm", *node_mapT);
 #endif
 
   // IK, 1/23/15: I've commented out the guts of this function.  It is
@@ -3634,8 +3636,8 @@ Aeras::SpectralDiscretization::updateMesh()
 
 #ifdef WRITE_TO_MATRIX_MARKET_TO_MM_FILE
   //write overlap maps to matrix market file for debug
-  Tpetra_MatrixMarket_Writer::writeMapFile("overlap_mapT.mm", *overlap_mapT);
-  Tpetra_MatrixMarket_Writer::writeMapFile("overlap_node_mapT.mm", *overlap_node_mapT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile("overlap_mapT.mm", *overlap_mapT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile("overlap_node_mapT.mm", *overlap_node_mapT);
 #endif
 
     // Note that getCoordinates has not been converted to use the
@@ -3670,11 +3672,11 @@ Aeras::SpectralDiscretization::updateMesh()
 
 #ifdef WRITE_TO_MATRIX_MARKET_TO_MM_FILE
   Teuchos::RCP<Tpetra_CrsMatrix> ImplicitMatrix = Teuchos::rcp(new Tpetra_CrsMatrix(implicit_graphT));
-  Tpetra_MatrixMarket_Writer::writeSparseFile("ImplicitMatrix.mm", ImplicitMatrix);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile("ImplicitMatrix.mm", ImplicitMatrix);
   Teuchos::RCP<Tpetra_CrsMatrix> Matrix = Teuchos::rcp(new Tpetra_CrsMatrix(graphT));
-  Tpetra_MatrixMarket_Writer::writeSparseFile("Matrix.mm", Matrix);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile("Matrix.mm", Matrix);
   Teuchos::RCP<Tpetra_CrsMatrix> OverlapMatrix = Teuchos::rcp(new Tpetra_CrsMatrix(overlap_graphT));
-  Tpetra_MatrixMarket_Writer::writeSparseFile("OverlapMatrix.mm", OverlapMatrix);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeSparseFile("OverlapMatrix.mm", OverlapMatrix);
 #endif
 
   // IK, 1/23/15, FIXME: to implement -- transform mesh based on new

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -37,6 +37,8 @@
 
 #include <stk_mesh/base/FEMHelpers.hpp>
 
+#include <MatrixMarket_Tpetra.hpp>
+
 #ifdef ALBANY_SEACAS
 #include <Ionit_Initializer.h>
 #include <netcdf.h>
@@ -734,19 +736,19 @@ Albany::STKDiscretization::writeCoordsToMatrixMarket() const
       Teuchos::RCP<Tpetra_Vector> xCoords_serialT =
           Teuchos::rcp(new Tpetra_Vector(serial_mapT));
       xCoords_serialT->doImport(*xCoordsT, *importOperatorT, Tpetra::INSERT);
-      Tpetra_MatrixMarket_Writer::writeDenseFile("xCoords.mm", xCoords_serialT);
+      Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("xCoords.mm", xCoords_serialT);
     } else
-      Tpetra_MatrixMarket_Writer::writeDenseFile("xCoords.mm", xCoordsT);
+      Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("xCoords.mm", xCoordsT);
     if (coordMV->getNumVectors() > 1) {
       Teuchos::RCP<const Tpetra_Vector> yCoordsT = coordMV->getVector(1);
       if (node_mapT->getComm()->getSize() > 1) {
         Teuchos::RCP<Tpetra_Vector> yCoords_serialT =
             Teuchos::rcp(new Tpetra_Vector(serial_mapT));
         yCoords_serialT->doImport(*yCoordsT, *importOperatorT, Tpetra::INSERT);
-        Tpetra_MatrixMarket_Writer::writeDenseFile(
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(
             "yCoords.mm", yCoords_serialT);
       } else
-        Tpetra_MatrixMarket_Writer::writeDenseFile("yCoords.mm", yCoordsT);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("yCoords.mm", yCoordsT);
     }
     if (coordMV->getNumVectors() > 2) {
       Teuchos::RCP<const Tpetra_Vector> zCoordsT = coordMV->getVector(2);
@@ -754,10 +756,10 @@ Albany::STKDiscretization::writeCoordsToMatrixMarket() const
         Teuchos::RCP<Tpetra_Vector> zCoords_serialT =
             Teuchos::rcp(new Tpetra_Vector(serial_mapT));
         zCoords_serialT->doImport(*zCoordsT, *importOperatorT, Tpetra::INSERT);
-        Tpetra_MatrixMarket_Writer::writeDenseFile(
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile(
             "zCoords.mm", zCoords_serialT);
       } else
-        Tpetra_MatrixMarket_Writer::writeDenseFile("zCoords.mm", zCoordsT);
+        Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeDenseFile("zCoords.mm", zCoordsT);
     }
   }
 }
@@ -3620,8 +3622,8 @@ Albany::STKDiscretization::updateMesh()
 
 #ifdef OUTPUT_TO_SCREEN
   // write owned maps to matrix market file for debug
-  Tpetra_MatrixMarket_Writer::writeMapFile("mapT0.mm", *mapT);
-  Tpetra_MatrixMarket_Writer::writeMapFile("node_mapT0.mm", *node_mapT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile("mapT0.mm", *mapT);
+  Tpetra::MatrixMarket::Writer<Tpetra_CrsMatrix>::writeMapFile("node_mapT0.mm", *node_mapT);
 #endif
 
   setupMLCoords();


### PR DESCRIPTION
Splitting the data types into multiple headers, and removing some typedefs.

This has zero impact on the current code (all the headers are still included by Albany_DataTypes.hpp), but create a more organized set of types. Ideally, one should not include Albany_DataTypes.hpp, unless all types are needed (e.g., Albany_Application).

The idea behind the split is to separate conceptual areas of the library. Most notably, the model part (Thyra-based), the linear algebra part (Tpetra-based), and the FE-assembly part (Phalanx-Sacado-based).

I did not include a reorganization of the types into namespaces (most notably, wrapping all types (and all namespaces) inside Albany namespace), since it would be a very large set of changes (though, imho, more structured and organized).