### PR TITLE
Removed calls to deprecated function in Trilinos

### DIFF
--- a/src/Petra_Converters.hpp
+++ b/src/Petra_Converters.hpp
@@ -29,20 +29,17 @@ Teuchos::RCP<const Epetra_Map> TpetraMap_To_EpetraMap(const Teuchos::RCP<const T
 //EpetraMap_To_TpetraMap: takes in Epetra_Map object, converts it to its equivalent Tpetra::Map object,
 //and returns an RCP pointer to this Tpetra::Map
 Teuchos::RCP<const Tpetra_Map> EpetraMap_To_TpetraMap(const Teuchos::RCP<const Epetra_Map>& epetraMap_,
-                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& comm_,
-                                                      const Teuchos::RCP< KokkosNode > &node = KokkosClassic::Details::getNode< KokkosNode >());
+                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& comm_);
 
 //EpetraMap_To_TpetraMap: takes in Epetra_Map object, converts it to its equivalent Tpetra::Map object,
 //and returns an RCP pointer to this Tpetra::Map
 Teuchos::RCP<const Tpetra_Map> EpetraMap_To_TpetraMap(const Epetra_Map& epetraMap_,
-                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& comm_,
-                                                      const Teuchos::RCP< KokkosNode > &node = KokkosClassic::Details::getNode< KokkosNode >());
+                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& comm_);
 
 //EpetraMap_To_TpetraMap: takes in Epetra_Map object, converts it to its equivalent Tpetra::Map object,
 //and returns an RCP pointer to this Tpetra::Map
 Teuchos::RCP<const Tpetra_Map> EpetraMap_To_TpetraMap(const Epetra_BlockMap& epetraMap_,
-                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& comm_,
-                                                      const Teuchos::RCP< KokkosNode > &node = KokkosClassic::Details::getNode< KokkosNode >());
+                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& comm_);
 
 Teuchos::RCP<Epetra_CrsGraph> TpetraCrsGraph_To_EpetraCrsGraph(const Teuchos::RCP<const Tpetra_CrsGraph>& tpetraCrsGraph_,
                                                                 const Teuchos::RCP<const Epetra_Comm>& comm);
@@ -69,13 +66,11 @@ void TpetraVector_To_EpetraVector(const Teuchos::RCP<const Tpetra_Vector>& tpetr
 
 //EpetraVector_To_TpetraVectorConst: copies const Epetra_Vector to const Tpetra_Vector
 Teuchos::RCP<const Tpetra_Vector> EpetraVector_To_TpetraVectorConst(const Epetra_Vector& epetraVector_,
-                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                               const Teuchos::RCP< KokkosNode > &node = KokkosClassic::Details::getNode< KokkosNode >());
+                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_);
 
 //EpetraVector_To_TpetraVectorNonConst: copies non-const Epetra_Vector to non-const Tpetra_Vector
 Teuchos::RCP<Tpetra_Vector> EpetraVector_To_TpetraVectorNonConst(const Epetra_Vector& epetraVector_,
-                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                               const Teuchos::RCP< KokkosNode > &node = KokkosClassic::Details::getNode< KokkosNode >());
+                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_);
 
 //TpetraMultiVector_To_EpetraMultiVector: copies Tpetra::MultiVector object into its analogous
 //Epetra_MultiVector object
@@ -84,13 +79,11 @@ void TpetraMultiVector_To_EpetraMultiVector(const Teuchos::RCP<const Tpetra_Mult
 
 //EpetraMultiVector_To_TpetraMultiVectorConst: copies Epetra_MultiVector to const Tpetra_MultiVector
 Teuchos::RCP<Tpetra_MultiVector> EpetraMultiVector_To_TpetraMultiVector(const Epetra_MultiVector& epetraMV_,
-                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                               const Teuchos::RCP< KokkosNode > &node = KokkosClassic::Details::getNode< KokkosNode >());
+                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_);
 
 //EpetraCrsMatrix_To_TpetraCrsMatrix: copies Epetra_CrsMatrix to its analogous Tpetra_CrsMatrix
 Teuchos::RCP<Tpetra_CrsMatrix> EpetraCrsMatrix_To_TpetraCrsMatrix(Epetra_CrsMatrix& epetraMatrix_,
-                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                               const Teuchos::RCP< KokkosNode > &node = KokkosClassic::Details::getNode< KokkosNode >());
+                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_);
 
 
 // Convenience class for conversions. One use case is to inherit from this class

--- a/src/Petra_Converters_64.cpp
+++ b/src/Petra_Converters_64.cpp
@@ -41,8 +41,7 @@ Teuchos::RCP<const Epetra_Map> Petra::TpetraMap_To_EpetraMap(const Teuchos::RCP<
 //EpetraMap_To_TpetraMap: takes in Epetra_Map object, converts it to its equivalent Tpetra::Map object,
 //and returns an RCP pointer to this Tpetra::Map
 Teuchos::RCP<const Tpetra_Map> Petra::EpetraMap_To_TpetraMap(const Teuchos::RCP<const Epetra_Map>& epetraMap_,
-                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                      const Teuchos::RCP<KokkosNode>& nodeT_)
+                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& commT_)
 {
   const std::size_t numElements = Teuchos::as<std::size_t>(epetraMap_->NumMyElements());
   const auto indexBase = Teuchos::as<GO>(epetraMap_->IndexBase());
@@ -52,17 +51,16 @@ Teuchos::RCP<const Tpetra_Map> Petra::EpetraMap_To_TpetraMap(const Teuchos::RCP<
     for(LO i=0; i < numElements; i++)
        indices[i] = epetra_indices[i];
     const Tpetra::global_size_t computeGlobalElements = Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
-    return Teuchos::rcp(new Tpetra_Map(computeGlobalElements, indices, indexBase, commT_, nodeT_));
+    return Teuchos::rcp(new Tpetra_Map(computeGlobalElements, indices, indexBase, commT_));
   } else {
-    return Teuchos::rcp(new Tpetra_Map(numElements, indexBase, commT_, Tpetra::LocallyReplicated, nodeT_));
+    return Teuchos::rcp(new Tpetra_Map(numElements, indexBase, commT_, Tpetra::LocallyReplicated));
   }
 }
 
 //EpetraMap_To_TpetraMap: takes in Epetra_Map object, converts it to its equivalent Tpetra::Map object,
 //and returns an RCP pointer to this Tpetra::Map
 Teuchos::RCP<const Tpetra_Map> Petra::EpetraMap_To_TpetraMap(const Epetra_Map& epetraMap_,
-                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                      const Teuchos::RCP<KokkosNode>& nodeT_)
+                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& commT_)
 {
   const std::size_t numElements = Teuchos::as<std::size_t>(epetraMap_.NumMyElements());
   const auto indexBase = Teuchos::as<GO>(epetraMap_.IndexBase());
@@ -72,17 +70,16 @@ Teuchos::RCP<const Tpetra_Map> Petra::EpetraMap_To_TpetraMap(const Epetra_Map& e
     for(LO i=0; i < numElements; i++)
        indices[i] = epetra_indices[i];
     const Tpetra::global_size_t computeGlobalElements = Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
-    return Teuchos::rcp(new Tpetra_Map(computeGlobalElements, indices, indexBase, commT_, nodeT_));
+    return Teuchos::rcp(new Tpetra_Map(computeGlobalElements, indices, indexBase, commT_));
   } else {
-    return Teuchos::rcp(new Tpetra_Map(numElements, indexBase, commT_, Tpetra::LocallyReplicated, nodeT_));
+    return Teuchos::rcp(new Tpetra_Map(numElements, indexBase, commT_, Tpetra::LocallyReplicated));
   }
 }
 
 //EpetraMap_To_TpetraMap: takes in Epetra_Map object, converts it to its equivalent Tpetra::Map object,
 //and returns an RCP pointer to this Tpetra::Map
 Teuchos::RCP<const Tpetra_Map> Petra::EpetraMap_To_TpetraMap(const Epetra_BlockMap& epetraMap_,
-                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                      const Teuchos::RCP<KokkosNode>& nodeT_)
+                                                      const Teuchos::RCP<const Teuchos::Comm<int> >& commT_)
 {
   const std::size_t numElements = Teuchos::as<std::size_t>(epetraMap_.NumMyElements());
   const auto indexBase = Teuchos::as<GO>(epetraMap_.IndexBase());
@@ -92,9 +89,9 @@ Teuchos::RCP<const Tpetra_Map> Petra::EpetraMap_To_TpetraMap(const Epetra_BlockM
     for(LO i=0; i < numElements; i++)
        indices[i] = epetra_indices[i];
     const Tpetra::global_size_t computeGlobalElements = Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid();
-    return Teuchos::rcp(new Tpetra_Map(computeGlobalElements, indices, indexBase, commT_, nodeT_));
+    return Teuchos::rcp(new Tpetra_Map(computeGlobalElements, indices, indexBase, commT_));
   } else {
-    return Teuchos::rcp(new Tpetra_Map(numElements, indexBase, commT_, Tpetra::LocallyReplicated, nodeT_));
+    return Teuchos::rcp(new Tpetra_Map(numElements, indexBase, commT_, Tpetra::LocallyReplicated));
   }
 }
 
@@ -247,11 +244,10 @@ void Petra::TpetraMultiVector_To_EpetraMultiVector(const Teuchos::RCP<const Tpet
 
 //EpetraVector_To_TpetraVectorConst: copies Epetra_Vector to const Tpetra_Vector
 Teuchos::RCP<const Tpetra_Vector> Petra::EpetraVector_To_TpetraVectorConst(const Epetra_Vector& epetraVector_,
-                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                               const Teuchos::RCP<KokkosNode>& nodeT_)
+                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_)
 {
   //get map from epetraVector_ and convert to Tpetra::Map
-  auto mapT = EpetraMap_To_TpetraMap(epetraVector_.Map(), commT_, nodeT_);
+  auto mapT = EpetraMap_To_TpetraMap(epetraVector_.Map(), commT_);
   ST *values;
   epetraVector_.ExtractView(&values);
   Teuchos::ArrayView<ST> valuesAV = Teuchos::arrayView(values, mapT->getGlobalNumElements());
@@ -261,11 +257,10 @@ Teuchos::RCP<const Tpetra_Vector> Petra::EpetraVector_To_TpetraVectorConst(const
 
 //EpetraMultiVector_To_TpetraMultiVector: copies Epetra_MultiVector to non-const Tpetra_MultiVector
 Teuchos::RCP<Tpetra_MultiVector> Petra::EpetraMultiVector_To_TpetraMultiVector(const Epetra_MultiVector& epetraMV_,
-                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                               const Teuchos::RCP<KokkosNode>& nodeT_)
+                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_)
 {
   //get map from epetraMV_ and convert to Tpetra::Map
-  auto mapT = EpetraMap_To_TpetraMap(epetraMV_.Map(), commT_, nodeT_);
+  auto mapT = EpetraMap_To_TpetraMap(epetraMV_.Map(), commT_);
   //copy values from epetraMV_
   int numVectors = epetraMV_.NumVectors();
   int Length;
@@ -280,11 +275,10 @@ Teuchos::RCP<Tpetra_MultiVector> Petra::EpetraMultiVector_To_TpetraMultiVector(c
 
 //EpetraVector_To_TpetraVectorNonConst: copies Epetra_Vector to non-const Tpetra_Vector
 Teuchos::RCP<Tpetra_Vector> Petra::EpetraVector_To_TpetraVectorNonConst(const Epetra_Vector& epetraVector_,
-                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                               const Teuchos::RCP<KokkosNode>& nodeT_)
+                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_)
 {
   //get map from epetraVector_ and convert to Tpetra::Map
-  auto mapT = EpetraMap_To_TpetraMap(epetraVector_.Map(), commT_, nodeT_);
+  auto mapT = EpetraMap_To_TpetraMap(epetraVector_.Map(), commT_);
   ST *values;
   epetraVector_.ExtractView(&values);
   Teuchos::ArrayView<ST> valuesAV = Teuchos::arrayView(values, mapT->getGlobalNumElements());
@@ -294,14 +288,13 @@ Teuchos::RCP<Tpetra_Vector> Petra::EpetraVector_To_TpetraVectorNonConst(const Ep
 
 //EpetraCrsMatrix_To_TpetraCrsMatrix: copies Epetra_CrsMatrix to its analogous Tpetra_CrsMatrix
 Teuchos::RCP<Tpetra_CrsMatrix> Petra::EpetraCrsMatrix_To_TpetraCrsMatrix(Epetra_CrsMatrix& epetraCrsMatrix_,
-                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_,
-                                                               const Teuchos::RCP<KokkosNode>& nodeT_)
+                                                               const Teuchos::RCP<const Teuchos::Comm<int> >& commT_)
 {
   //get row map of Epetra::CrsMatrix & convert to Tpetra::Map
-  auto tpetraRowMap_ = EpetraMap_To_TpetraMap(epetraCrsMatrix_.RowMap(), commT_, nodeT_);
+  auto tpetraRowMap_ = EpetraMap_To_TpetraMap(epetraCrsMatrix_.RowMap(), commT_);
 
   //get col map of Epetra::CrsMatrix & convert to Tpetra::Map
-  auto tpetraColMap_ = EpetraMap_To_TpetraMap(epetraCrsMatrix_.ColMap(), commT_, nodeT_);
+  auto tpetraColMap_ = EpetraMap_To_TpetraMap(epetraCrsMatrix_.ColMap(), commT_);
 
   //get CrsGraph of Epetra::CrsMatrix & convert to Tpetra::CrsGraph
   const Epetra_CrsGraph epetraCrsGraph_ = epetraCrsMatrix_.Graph();

--- a/src/disc/stk/Albany_ExtrudedSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_ExtrudedSTKMeshStruct.cpp
@@ -264,21 +264,21 @@ void Albany::ExtrudedSTKMeshStruct::setFieldAndBulkData(
   {
     indices[i] = bulkData2D.identifier(nodes2D[i]) - 1;
   }
-  Teuchos::RCP<const Tpetra_Map> nodes_map = Tpetra::createNonContigMapWithNode<LO, Tpetra_GO, KokkosNode>(indices(),comm,KokkosClassic::Details::getNode<KokkosNode>());
+  Teuchos::RCP<const Tpetra_Map> nodes_map = Tpetra::createNonContigMapWithNode<LO, Tpetra_GO, KokkosNode>(indices(),comm);
 
   indices.resize(cells2D.size());
   for (int i=0; i<cells2D.size(); ++i)
   {
     indices[i] = bulkData2D.identifier(cells2D[i]) -1;
   }
-  Teuchos::RCP<const Tpetra_Map> cells_map = Tpetra::createNonContigMapWithNode<LO, Tpetra_GO, KokkosNode>(indices(),comm,KokkosClassic::Details::getNode<KokkosNode>());
+  Teuchos::RCP<const Tpetra_Map> cells_map = Tpetra::createNonContigMapWithNode<LO, Tpetra_GO, KokkosNode>(indices(),comm);
 
   indices.resize(sides2D.size());
   for (int i=0; i<sides2D.size(); ++i)
   {
     indices[i] = bulkData2D.identifier(sides2D[i]) -1;
   }
-  Teuchos::RCP<const Tpetra_Map> sides_map = Tpetra::createNonContigMapWithNode<LO, Tpetra_GO, KokkosNode>(indices(),comm,KokkosClassic::Details::getNode<KokkosNode>());
+  Teuchos::RCP<const Tpetra_Map> sides_map = Tpetra::createNonContigMapWithNode<LO, Tpetra_GO, KokkosNode>(indices(),comm);
 
   GO maxGlobalElements2dId = cells_map->getMaxAllGlobalIndex() + 1;
   GO maxGlobalVertices2dId = nodes_map->getMaxAllGlobalIndex() + 1;

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -1113,8 +1113,8 @@ void Albany::GenericSTKMeshStruct::loadRequiredInputFields (const AbstractFieldC
   // Creating the serial and parallel node maps
   const Tpetra::global_size_t INVALID = Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid ();
 
-  Teuchos::RCP<const Tpetra_Map> nodes_map = Tpetra::createNonContigMapWithNode<LO, Tpetra_GO, KokkosNode> (nodeIndices, commT, KokkosClassic::Details::getNode<KokkosNode>());
-  Teuchos::RCP<const Tpetra_Map> elems_map = Tpetra::createNonContigMapWithNode<LO, Tpetra_GO, KokkosNode> (elemIndices, commT, KokkosClassic::Details::getNode<KokkosNode>());
+  Teuchos::RCP<const Tpetra_Map> nodes_map = Tpetra::createNonContigMapWithNode<LO, Tpetra_GO, KokkosNode> (nodeIndices, commT);
+  Teuchos::RCP<const Tpetra_Map> elems_map = Tpetra::createNonContigMapWithNode<LO, Tpetra_GO, KokkosNode> (elemIndices, commT);
 
   // Check whether we need the serial map or not. The only scenario where we DO need it is if we are
   // loading a field from an ASCII file. So let's check the fields info to see if that's the case.
@@ -1890,7 +1890,7 @@ Albany::GenericSTKMeshStruct::create_root_map (Teuchos::Array<Tpetra_GO>& nodeEl
   num_global_elems = allElemsToRoot.size();
   Teuchos::broadcast(*commT,0,1,&num_global_elems);
 
-  return Teuchos::rcp (new Tpetra_Map (num_global_elems,allElemsToRoot(),elem_base,commT,KokkosClassic::Details::getNode<KokkosNode>()));
+  return Teuchos::rcp (new Tpetra_Map (num_global_elems,allElemsToRoot(),elem_base,commT));
 }
 
 void


### PR DESCRIPTION
This PR addresses issue #324 (see the issue and commit comments for details).

The PR is very tiny, but I wanted it to go through a PR workflow (rather than merge in master) because it breaks backward compatibility, so it needs to be tracked.

The break is in the Petra conversion routines for maps: the last argument (the node) is no longer present. However, notice the the previous impl had a default for that argument, and nowhere in albany those functions were called passing an explicit last argument; insteady, all calls made use of the default value. Therefore, unless someone is using those functions passing an explicit node, the change should be unharmful.