### PR TITLE
[WIP] Add more flexibility to Fad type choice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1004,21 +1004,56 @@ ENDIF()
 ## Other Albany Template Options here:
 MESSAGE("\nAlbany Templated Data Type Options:")
 
-# Set FAD data type to static SLFAD if requested.
-OPTION(ENABLE_FAST_FELIX "Flag to turn on Code Optimization for FELIX that
-may break other physics" OFF)
-OPTION(ENABLE_SLFAD "Flag to turn on Code Optimization for ALBANY that
-may break other physics" OFF)
-
-SET(SLFAD_SIZE 32 CACHE INT "set Sacado SLFad size")
-
-IF (ENABLE_SLFAD OR ENABLE_FAST_FELIX)
-  SET(ALBANY_FAST_FELIX ON)
-  SET(ALBANY_SLFAD_SIZE ${SLFAD_SIZE})
-  MESSAGE("-- FADType   is SLFAD, compiling with -DALBANY_FAST_FELIX -DALBANY_SLFAD_SIZE=${SLFAD_SIZE}")
-  MESSAGE("---> WARNING: problems with elemental DOFs > ${SLFAD_SIZE} will fail.")
+# Set FAD data type
+SET(ENABLE_FAD_TYPE "DFad" CACHE STRING "Sacado forward mode automatic differentiation data type")
+IF(ENABLE_FAD_TYPE STREQUAL "SFad")
+  SET(ALBANY_FAD_TYPE_SFAD TRUE)
+  SET(ALBANY_SFAD_SIZE 32 CACHE INT "Number of derivative components chosen at compile-time for AD")
+  MESSAGE("-- FAD_TYPE  is SFad, compiling with -DALBANY_FAD_TYPE_SFAD -DALBANY_SFAD_SIZE=${ALBANY_SFAD_SIZE}")
+  MESSAGE("---> WARNING: problems with elemental DOFs > ${ALBANY_SFAD_SIZE} will fail")
+ELSEIF(ENABLE_FAD_TYPE STREQUAL "SLFad")
+  SET(ALBANY_FAD_TYPE_SLFAD TRUE)
+  SET(ALBANY_SLFAD_SIZE 32 CACHE INT "Maximum number of derivative components chosen at compile-time for AD")
+  MESSAGE("-- FAD_TYPE  is SLFad, compiling with -DALBANY_FAD_TYPE_SLFAD -DALBANY_SLFAD_SIZE=${ALBANY_SLFAD_SIZE}")
+  MESSAGE("---> WARNING: problems with elemental DOFs > ${ALBANY_SLFAD_SIZE} will fail")
+ELSEIF(ENABLE_FAD_TYPE STREQUAL "DFad")
+  MESSAGE("-- FAD_TYPE  is DFad (default)")
 ELSE()
-  MESSAGE("-- FADType   is DFAD (default).")
+  MESSAGE(FATAL_ERROR,
+          "\nError: ENABLE_FAD_TYPE = ${ENABLE_FAD_TYPE} is not recognized! Options: SFad, SLFad, DFad (default)")
+ENDIF()
+
+# Set FAD data type for Tangent
+SET(ENABLE_TAN_FAD_TYPE "DFad" CACHE STRING "Sacado forward mode automatic differentiation data type for Tangent")
+IF(ENABLE_TAN_FAD_TYPE STREQUAL "SFad")
+  SET(ALBANY_TAN_FAD_TYPE_SFAD TRUE)
+  SET(ALBANY_TAN_SFAD_SIZE 32 CACHE INT "Number of derivative components chosen at compile-time for Tangent AD")
+  MESSAGE("-- TAN_FAD_TYPE is SFad, compiling with -DALBANY_TAN_FAD_TYPE_SFAD -DALBANY_TAN_SFAD_SIZE=${ALBANY_TAN_SFAD_SIZE}")
+  MESSAGE("---> WARNING: problems with Tangent elemental DOFs > ${ALBANY_TAN_SFAD_SIZE} will fail")
+ELSEIF(ENABLE_TAN_FAD_TYPE STREQUAL "SLFad")
+  SET(ALBANY_TAN_FAD_TYPE_SLFAD TRUE)
+  SET(ALBANY_TAN_SLFAD_SIZE 32 CACHE INT "Maximum number of derivative components chosen at compile-time for Tangent AD")
+  MESSAGE("-- TAN_FAD_TYPE is SLFad, compiling with -DALBANY_TAN_FAD_TYPE_SLFAD -DALBANY_TAN_SLFAD_SIZE=${ALBANY_TAN_SLFAD_SIZE}")
+  MESSAGE("---> WARNING: problems with Tangent elemental DOFs > ${ALBANY_TAN_SLFAD_SIZE} will fail")
+ELSEIF(ENABLE_TAN_FAD_TYPE STREQUAL "DFad")
+  MESSAGE("-- TAN_FAD_TYPE is DFad (default)")
+ELSE()
+  MESSAGE(FATAL_ERROR,
+          "\nError: ENABLE_TAN_FAD_TYPE = ${ENABLE_TAN_FAD_TYPE} is not recognized! Options: SFad, SLFad, DFad (default)")
+ENDIF()
+
+# Check if FAD data type is the same
+IF(ENABLE_FAD_TYPE STREQUAL ENABLE_TAN_FAD_TYPE)
+  IF(ALBANY_FAD_TYPE_SFAD AND NOT ALBANY_SFAD_SIZE EQUAL ALBANY_TAN_SFAD_SIZE)
+    SET(ALBANY_FADTYPE_NOTEQUAL_TANFADTYPE TRUE)
+    MESSAGE("-- SFAD_SIZE is not TAN_SFAD_SIZE, compiling with -DALBANY_FADTYPE_NOTEQUAL_TANFADTYPE")
+  ELSEIF(ALBANY_FAD_TYPE_SLFAD AND NOT ALBANY_SLFAD_SIZE EQUAL ALBANY_TAN_SLFAD_SIZE)
+    SET(ALBANY_FADTYPE_NOTEQUAL_TANFADTYPE TRUE)
+    MESSAGE("-- SLFAD_SIZE is not TAN_SLFAD_SIZE, compiling with -DALBANY_FADTYPE_NOTEQUAL_TANFADTYPE")
+  ENDIF()
+ELSE()
+  SET(ALBANY_FADTYPE_NOTEQUAL_TANFADTYPE TRUE)
+  MESSAGE("-- FAD_TYPE is not TAN_FAD_TYPE, compiling with -DALBANY_FADTYPE_NOTEQUAL_TANFADTYPE")
 ENDIF()
 
 # optionally disable the use of the Trilinos stokhos package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1004,6 +1004,15 @@ ENDIF()
 ## Other Albany Template Options here:
 MESSAGE("\nAlbany Templated Data Type Options:")
 
+# Throw error if using ENABLE_FAST_FELIX
+IF(ENABLE_FAST_FELIX)
+  MESSAGE(FATAL_ERROR
+  "\nError: ENABLE_FAST_FELIX has been removed! Use ENABLE_FAD_TYPE instead.
+  Example for a tetrahedral mesh in FELIX:
+    -D ENABLE_FAD_TYPE:STRING=SFad
+    -D ALBANY_SFAD_SIZE=8")
+ENDIF()
+
 # Set FAD data type
 SET(ENABLE_FAD_TYPE "DFad" CACHE STRING "Sacado forward mode automatic differentiation data type")
 IF(ENABLE_FAD_TYPE STREQUAL "SFad")
@@ -1019,8 +1028,9 @@ ELSEIF(ENABLE_FAD_TYPE STREQUAL "SLFad")
 ELSEIF(ENABLE_FAD_TYPE STREQUAL "DFad")
   MESSAGE("-- FAD_TYPE  is DFad (default)")
 ELSE()
-  MESSAGE(FATAL_ERROR,
-          "\nError: ENABLE_FAD_TYPE = ${ENABLE_FAD_TYPE} is not recognized! Options: SFad, SLFad, DFad (default)")
+  MESSAGE(FATAL_ERROR
+  "\nError: ENABLE_FAD_TYPE = ${ENABLE_FAD_TYPE} is not recognized!
+  Options: SFad, SLFad, DFad (default)")
 ENDIF()
 
 # Set FAD data type for Tangent
@@ -1038,8 +1048,9 @@ ELSEIF(ENABLE_TAN_FAD_TYPE STREQUAL "SLFad")
 ELSEIF(ENABLE_TAN_FAD_TYPE STREQUAL "DFad")
   MESSAGE("-- TAN_FAD_TYPE is DFad (default)")
 ELSE()
-  MESSAGE(FATAL_ERROR,
-          "\nError: ENABLE_TAN_FAD_TYPE = ${ENABLE_TAN_FAD_TYPE} is not recognized! Options: SFad, SLFad, DFad (default)")
+  MESSAGE(FATAL_ERROR
+  "\nError: ENABLE_TAN_FAD_TYPE = ${ENABLE_TAN_FAD_TYPE} is not recognized!
+  Options: SFad, SLFad, DFad")
 ENDIF()
 
 # Check if FAD data type is the same

--- a/src/Aeras/evaluators/Aeras_ComputeBasisFunctions_Def.hpp
+++ b/src/Aeras/evaluators/Aeras_ComputeBasisFunctions_Def.hpp
@@ -113,7 +113,7 @@ postRegistrationSetup(typename Traits::SetupData d,
   }
 
   std::vector<PHX::index_size_type> ddims_;
-#ifdef  ALBANY_FAST_FELIX
+#ifdef ALBANY_FAD_TYPE_SLFAD
   ddims_.push_back(ALBANY_SLFAD_SIZE);
 #else
   ddims_.push_back(95);

--- a/src/Albany_SacadoTypes.hpp
+++ b/src/Albany_SacadoTypes.hpp
@@ -20,6 +20,7 @@
 #include "Sacado_ELRCacheFad_DFad.hpp"
 #include "Sacado_Fad_DFad.hpp"
 #include "Sacado_Fad_SLFad.hpp"
+#include "Sacado_Fad_SFad.hpp"
 #include "Sacado_ELRFad_SLFad.hpp"
 #include "Sacado_ELRFad_SFad.hpp"
 #include "Sacado_CacheFad_DFad.hpp"
@@ -33,17 +34,21 @@
 // ******************************************************************
 
 // Switch between dynamic and static FAD types
-#ifdef ALBANY_FAST_FELIX
-  // Code templated on data type need to know if FadType and TanFadType
-  // are the same or different typdefs
-#define ALBANY_FADTYPE_NOTEQUAL_TANFADTYPE
-  typedef Sacado::Fad::SLFad<RealType, ALBANY_SLFAD_SIZE> FadType;
+#if defined(ALBANY_FAD_TYPE_SFAD)
+typedef Sacado::Fad::SFad<RealType, ALBANY_SFAD_SIZE> FadType;
+#elif defined(ALBANY_FAD_TYPE_SLFAD)
+typedef Sacado::Fad::SLFad<RealType, ALBANY_SLFAD_SIZE> FadType;
 #else
-#define ALBANY_SFAD_SIZE 300
-  typedef Sacado::Fad::DFad<RealType> FadType;
+typedef Sacado::Fad::DFad<RealType> FadType;
 #endif
 
+#if defined(ALBANY_TAN_FAD_TYPE_SFAD)
+typedef Sacado::Fad::SFad<RealType, ALBANY_TAN_SFAD_SIZE> TanFadType;
+#elif defined(ALBANY_TAN_FAD_TYPE_SLFAD)
+typedef Sacado::Fad::SLFad<RealType, ALBANY_TAN_SLFAD_SIZE> TanFadType;
+#else
 typedef Sacado::Fad::DFad<RealType> TanFadType;
+#endif
 
 struct SPL_Traits {
   template <class T> struct apply {

--- a/src/Albany_config.h.in
+++ b/src/Albany_config.h.in
@@ -97,8 +97,16 @@
 // FTZ/DAZ macro
 #cmakedefine ALBANY_FLUSH_DENORMALS
 
-// Static SLFAD data type
-#cmakedefine ALBANY_SLFAD_SIZE ${SLFAD_SIZE}
+// FAD data type
+#cmakedefine ALBANY_FAD_TYPE_SFAD
+#cmakedefine ALBANY_SFAD_SIZE ${ALBANY_SFAD_SIZE}
+#cmakedefine ALBANY_FAD_TYPE_SLFAD
+#cmakedefine ALBANY_SLFAD_SIZE ${ALBANY_SLFAD_SIZE}
+#cmakedefine ALBANY_TAN_FAD_TYPE_SFAD
+#cmakedefine ALBANY_TAN_SFAD_SIZE ${ALBANY_TAN_SFAD_SIZE}
+#cmakedefine ALBANY_TAN_FAD_TYPE_SLFAD
+#cmakedefine ALBANY_TAN_SLFAD_SIZE ${ALBANY_TAN_SLFAD_SIZE}
+#cmakedefine ALBANY_FADTYPE_NOTEQUAL_TANFADTYPE
 
 // ============= Macros used to enable additional code, not limited to a particular package ============== //
 
@@ -128,7 +136,6 @@
   // --- FELIX
   #cmakedefine CISM_HAS_FELIX
   #cmakedefine MPAS_HAS_FELIX
-  #cmakedefine ALBANY_FAST_FELIX
   #cmakedefine CISM_CHECK_COMPARISONS
   #cmakedefine REDUCED_COMM
   #cmakedefine CISM_USE_EPETRA


### PR DESCRIPTION
This commit removes the ENABLE_SLFAD and ALBANY_FAST_FELIX config
options and replaces them with the more generic ENABLE_FAD_TYPE
and ENABLE_TAN_FAD_TYPE options. This allows the user to set
the desired Fad type (SFad, SLFad, DFad) for all specializations
or the Tangent, repectively. Sizes are set with ALBANY_SFAD_SIZE,
ALBANY_SLFAD_SIZE, ALBANY_TAN_SFAD_SIZE or ALBANY_TAN_SLFAD_SIZE.

This allows us to deal with issue #330 although the issue still
remains for DFad Tangent on GPUs.