### PR TITLE
Purge deprecated calls

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -234,21 +234,6 @@ void Albany::Application::initialSetUp(
     tangent_deriv_dim = 1;
   }
 
-#ifdef ALBANY_EPETRA
-#ifdef ALBANY_MOR
-  bool MOR_problem = problemParams->isSublist("Model Order Reduction");
-  if (MOR_problem)
-  {
-    bool MOR_problem_named = Teuchos::sublist(problemParams, "Model Order Reduction")->isSublist("Reduced-Order Model");
-    if (MOR_problem_named)
-    {
-      Teuchos::RCP<Teuchos::ParameterList> morParams = Teuchos::sublist(Teuchos::sublist(problemParams, "Model Order Reduction", true), "Reduced-Order Model",true);
-      MOR_apply_bcs_ = morParams->get<bool>("Apply BCs", true);
-    }
-  }
-#endif //ALBANY_MOR
-#endif //ALBANY_EPETRA
-
   // Pull the number of solution vectors out of the problem and send them to the
   // discretization list, if the user specifies this in the problem
   Teuchos::ParameterList &discParams = params->sublist("Discretization");
@@ -927,12 +912,6 @@ void Albany::Application::finalSetUp(
     solveParams.get(sensitivityToken, *oldSensitivityFlag);
   }
 
-#ifdef ALBANY_MOR
-#if defined(ALBANY_EPETRA)
-  if (disc->supportsMOR())
-    morFacade = createMORFacade(disc, problemParams);
-#endif
-#endif
   // MPerego: Preforming post registration setup here to make sure that the
   // discretization is already created, so that  derivative dimensions are known.
   // Cannot do post registration right before the evaluate , as done for other
@@ -3594,14 +3573,6 @@ void Albany::Application::setupTangentWorksetInfo(
   workset.num_cols_p = num_cols_p;
   workset.param_offset = param_offset;
 }
-
-#ifdef ALBANY_MOR
-#if defined(ALBANY_EPETRA)
-Teuchos::RCP<Albany::MORFacade> Albany::Application::getMorFacade() {
-  return morFacade;
-}
-#endif
-#endif
 
 void Albany::Application::removeEpetraRelatedPLs(
     const Teuchos::RCP<Teuchos::ParameterList> &params) {

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -56,12 +56,6 @@
 
 #endif
 
-#if defined(ALBANY_MOR)
-#if defined(ALBANY_EPETRA)
-#include "MOR/Albany_MORFacade.hpp"
-#endif
-#endif
-
 // Forward declarations.
 namespace AAdapt {
 namespace rc {
@@ -477,12 +471,6 @@ public:
 
   void postRegSetup(std::string eval);
 
-#ifdef ALBANY_MOR
-#if defined(ALBANY_EPETRA)
-  Teuchos::RCP<MORFacade> getMorFacade();
-#endif
-#endif
-
 #if defined(ALBANY_LCM)
   double
   fixTime(double const current_time) const
@@ -771,12 +759,6 @@ protected:
 
   void determinePiroSolver(
       const Teuchos::RCP<Teuchos::ParameterList> &topLevelParams);
-
-#ifdef ALBANY_MOR
-#if defined(ALBANY_EPETRA)
-  Teuchos::RCP<MORFacade> morFacade;
-#endif
-#endif
 
   int derivatives_check_;
 

--- a/src/Albany_ModelFactory.cpp
+++ b/src/Albany_ModelFactory.cpp
@@ -14,13 +14,6 @@
 #endif
 #include "Albany_ModelEvaluatorT.hpp"
 
-
-#ifdef ALBANY_MOR
-#if defined(ALBANY_EPETRA)
-#include "MOR_ReducedOrderModelFactory.hpp"
-#endif
-#endif
-
 namespace Albany {
 
 using Teuchos::RCP;
@@ -42,14 +35,6 @@ RCP<EpetraExt::ModelEvaluator> ModelFactory::create() const
   // Wrap a decorator around the original model when an adaptive computation is requested.
 //  const RCP<AAdapt::AdaptiveModelFactory> adaptMdlFactory = app_->getAdaptSolMgr()->modelFactory();
 //  model = adaptMdlFactory->create(model);
-
-#ifdef ALBANY_MOR
-  if(app_->getDiscretization()->supportsMOR()){
-    // Wrap a decorator around the original model when a reduced-order computation is requested.
-    const RCP<MOR::ReducedOrderModelFactory> romFactory = app_->getMorFacade()->modelFactory();
-    model = romFactory->create(model);
-  }
-#endif
 
   return model;
 }

--- a/src/Albany_ObserverFactory.cpp
+++ b/src/Albany_ObserverFactory.cpp
@@ -13,12 +13,6 @@
 #include "Albany_RythmosObserver.hpp"
 #endif
 
-#ifdef ALBANY_MOR
-#if defined(ALBANY_EPETRA)
-#include "MOR_ObserverFactory.hpp"
-#endif
-#endif
-
 #include "Teuchos_ParameterList.hpp"
 
 #include <string>
@@ -34,12 +28,6 @@ Teuchos::RCP<NOX::Epetra::Observer>
 NOXObserverFactory::createInstance()
 {
   Teuchos::RCP<NOX::Epetra::Observer> result(new Albany_NOXObserver(app_));
-#ifdef ALBANY_MOR
-  if(app_->getDiscretization()->supportsMOR()){
-    const Teuchos::RCP<MOR::ObserverFactory> morObserverFactory = app_->getMorFacade()->observerFactory();
-    result = morObserverFactory->create(result);
-  }
-#endif
   return result;
 }
 
@@ -51,13 +39,6 @@ NOXStatelessObserverFactory (const Teuchos::RCP<Application> &app)
 Teuchos::RCP<NOX::Epetra::Observer>
 NOXStatelessObserverFactory::createInstance () {
   Teuchos::RCP<NOX::Epetra::Observer> result(new NOXStatelessObserver(app_));
-#ifdef ALBANY_MOR
-  if (app_->getDiscretization()->supportsMOR()) {
-    const Teuchos::RCP<MOR::ObserverFactory>
-      morObserverFactory = app_->getMorFacade()->observerFactory();
-    result = morObserverFactory->create(result);
-  }
-#endif
   return result;
 }
 #endif
@@ -71,12 +52,6 @@ Teuchos::RCP<Rythmos::IntegrationObserverBase<double> >
 RythmosObserverFactory::createInstance()
 {
   Teuchos::RCP<Rythmos::IntegrationObserverBase<double> > result(new Albany_RythmosObserver(app_));
-#ifdef ALBANY_MOR
-  if(app_->getDiscretization()->supportsMOR()){
-    const Teuchos::RCP<MOR::ObserverFactory> morObserverFactory = app_->getMorFacade()->observerFactory();
-    result = morObserverFactory->create(result);
-  }
-#endif
   return result;
 }
 #endif

--- a/src/Albany_TpetraTypes.hpp
+++ b/src/Albany_TpetraTypes.hpp
@@ -18,7 +18,6 @@
 
 // Tpetra includes
 #include "TpetraCore_config.h"
-#include "Tpetra_DefaultPlatform.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_CrsMatrix.hpp"

--- a/src/LCM/utils/dtk_interp_and_error/dtk_interp_and_error.cpp
+++ b/src/LCM/utils/dtk_interp_and_error/dtk_interp_and_error.cpp
@@ -147,7 +147,7 @@ interp_and_calc_error(
     tmo = stk::io::MeshField::LINEAR_INTERPOLATION;
   }
 
-  src_broker.add_all_mesh_fields_as_input_fields(tmo);
+  src_broker.add_all_mesh_fields_as_input_field_on_meshs(tmo);
   src_broker.populate_bulk_data();
 
   Teuchos::RCP<stk::mesh::BulkData> src_bulk_data =
@@ -195,7 +195,7 @@ interp_and_calc_error(
       target_mesh_input_file, "exodus", stk::io::READ_MESH);
   tgt_broker.set_active_mesh(tgt_input_index);
   tgt_broker.create_input_mesh();
-  tgt_broker.add_all_mesh_fields_as_input_fields(tmo);
+  tgt_broker.add_all_mesh_fields_as_input_field_on_meshs(tmo);
 
   // Put fields on target mesh
   // Add a nodal field to the interpolated target part.
@@ -203,24 +203,24 @@ interp_and_calc_error(
       tgt_broker.meta_data().declare_field<FieldType>(
           stk::topology::NODE_RANK, tgt_interp_field_name);
 
-  stk::mesh::put_field(
-      target_interp_field, tgt_broker.meta_data().universal_part(), neq);
+  stk::mesh::put_field_on_mesh(
+      target_interp_field, tgt_broker.meta_data().universal_part(), neq, nullptr);
 
   // Add a absolute error nodal field to the target part.
   FieldType& target_abs_error_field =
       tgt_broker.meta_data().declare_field<FieldType>(
           stk::topology::NODE_RANK, abs_err_field_name);
 
-  stk::mesh::put_field(
-      target_abs_error_field, tgt_broker.meta_data().universal_part(), neq);
+  stk::mesh::put_field_on_mesh(
+      target_abs_error_field, tgt_broker.meta_data().universal_part(), neq, nullptr);
 
   // Add a relative error nodal field to the target part.
   FieldType& target_rel_error_field =
       tgt_broker.meta_data().declare_field<FieldType>(
           stk::topology::NODE_RANK, rel_err_field_name);
 
-  stk::mesh::put_field(
-      target_rel_error_field, tgt_broker.meta_data().universal_part(), neq);
+  stk::mesh::put_field_on_mesh(
+      target_rel_error_field, tgt_broker.meta_data().universal_part(), neq, nullptr);
 
   // Create the target bulk data.
   tgt_broker.populate_bulk_data();
@@ -392,7 +392,7 @@ interp_and_calc_error(
 
     for (int interval = 0; interval < interpolation_intervals; interval++) {
       time = tbeg + delta * static_cast<double>(interval);
-      src_broker.read_defined_input_fields(time);
+      src_broker.read_defined_input_field_on_meshs(time);
     }
 
     time = tgt_io_region->get_state_time(tgt_time_step_indices[index]);
@@ -409,7 +409,7 @@ interp_and_calc_error(
 
     for (int interval = 0; interval < interpolation_intervals; interval++) {
       time = tbeg + delta * static_cast<double>(interval);
-      tgt_broker.read_defined_input_fields(time);
+      tgt_broker.read_defined_input_field_on_meshs(time);
     }
 
     // SOLUTION TRANSFER SETUP
@@ -680,7 +680,7 @@ interp_and_calc_error(
 #endif
     // Write step
     tgt_broker.begin_output_step(tgt_output_index, state_time);
-    tgt_broker.write_defined_output_fields(tgt_output_index);
+    tgt_broker.write_defined_output_field_on_meshs(tgt_output_index);
     tgt_broker.end_output_step(tgt_output_index);
   }
 }

--- a/src/LCM/utils/dtk_interp_and_error/interpolation_volume_to_ns.cpp
+++ b/src/LCM/utils/dtk_interp_and_error/interpolation_volume_to_ns.cpp
@@ -119,7 +119,7 @@ interpolate(
   if (interpolation_intervals > 1)
     tmo = stk::io::MeshField::LINEAR_INTERPOLATION;
 
-  src_broker.add_all_mesh_fields_as_input_fields(tmo);
+  src_broker.add_all_mesh_fields_as_input_field_on_meshs(tmo);
   src_broker.populate_bulk_data();
   Teuchos::RCP<stk::mesh::BulkData> src_bulk_data =
       Teuchos::rcpFromRef(src_broker.bulk_data());
@@ -161,7 +161,7 @@ interpolate(
 
     for (int interval = 0; interval < interpolation_intervals; interval++) {
       time = tbeg + delta * static_cast<double>(interval);
-      src_broker.read_defined_input_fields(time);
+      src_broker.read_defined_input_field_on_meshs(time);
     }
   }
 
@@ -199,7 +199,7 @@ interpolate(
       target_mesh_input_file, "exodus", stk::io::READ_MESH);
   tgt_broker.set_active_mesh(tgt_input_index);
   tgt_broker.create_input_mesh();
-  tgt_broker.add_all_mesh_fields_as_input_fields(tmo);
+  tgt_broker.add_all_mesh_fields_as_input_field_on_meshs(tmo);
 
   // Get source_field from source mesh
   FieldType* source_field = src_broker.meta_data().get_field<FieldType>(
@@ -225,12 +225,12 @@ interpolate(
   FieldType& target_interp_field =
       tgt_broker.meta_data().declare_field<FieldType>(
           stk::topology::NODE_RANK, tgt_interp_field_name);
-  stk::mesh::put_field(
-      target_interp_field, tgt_broker.meta_data().universal_part(), neq);
+  stk::mesh::put_field_on_mesh(
+      target_interp_field, tgt_broker.meta_data().universal_part(), neq, nullptr);
   FieldType& dirichlet_field = tgt_broker.meta_data().declare_field<FieldType>(
       stk::topology::NODE_RANK, "dirichlet_field");
-  stk::mesh::put_field(
-      dirichlet_field, tgt_broker.meta_data().universal_part(), neq);
+  stk::mesh::put_field_on_mesh(
+      dirichlet_field, tgt_broker.meta_data().universal_part(), neq, nullptr);
 
   // Create the target bulk data.
   tgt_broker.populate_bulk_data();
@@ -287,7 +287,7 @@ interpolate(
 
     for (int interval = 0; interval < interpolation_intervals; interval++) {
       time = tbeg + delta * static_cast<double>(interval);
-      tgt_broker.read_defined_input_fields(time);
+      tgt_broker.read_defined_input_field_on_meshs(time);
     }
   }
 
@@ -418,7 +418,7 @@ interpolate(
   else
     tgt_broker.add_field(tgt_output_index, dirichlet_field);
   tgt_broker.begin_output_step(tgt_output_index, 0.0);
-  tgt_broker.write_defined_output_fields(tgt_output_index);
+  tgt_broker.write_defined_output_field_on_meshs(tgt_output_index);
   tgt_broker.end_output_step(tgt_output_index);
 }
 

--- a/src/disc/stk/Aeras_SpectralDiscretization.cpp
+++ b/src/disc/stk/Aeras_SpectralDiscretization.cpp
@@ -2634,7 +2634,6 @@ void Aeras::SpectralDiscretization::computeWorksetInfo()
   typedef Albany::AbstractSTKFieldContainer::QPScalarState    QPScalarState;
   typedef Albany::AbstractSTKFieldContainer::QPVectorState    QPVectorState;
   typedef Albany::AbstractSTKFieldContainer::QPTensorState    QPTensorState;
-  typedef Albany::AbstractSTKFieldContainer::QPTensor3State   QPTensor3State;
   typedef Albany::AbstractSTKFieldContainer::ScalarState      ScalarState;
   typedef Albany::AbstractSTKFieldContainer::VectorState      VectorState;
   typedef Albany::AbstractSTKFieldContainer::TensorState      TensorState;
@@ -2646,7 +2645,6 @@ void Aeras::SpectralDiscretization::computeWorksetInfo()
   QPScalarState qpscalar_states = stkMeshStruct->getFieldContainer()->getQPScalarStates();
   QPVectorState qpvector_states = stkMeshStruct->getFieldContainer()->getQPVectorStates();
   QPTensorState qptensor_states = stkMeshStruct->getFieldContainer()->getQPTensorStates();
-  QPTensor3State qptensor3_states = stkMeshStruct->getFieldContainer()->getQPTensor3States();
   std::map<std::string, double>& time = stkMeshStruct->getFieldContainer()->getTime();
 
   for (std::size_t b = 0; b < buckets.size(); ++b)
@@ -2680,16 +2678,6 @@ void Aeras::SpectralDiscretization::computeWorksetInfo()
       // Debug
       // std::cout << "Buck.size(): " << buck.size() << " QPTFT dim[3]: "
       //           << array.dimension(3) << std::endl;
-      Albany::MDArray ar = array;
-      stateArrays.elemStateArrays[b][(*qpts)->name()] = ar;
-    }
-    for (QPTensor3State::iterator qpts = qptensor3_states.begin();
-              qpts != qptensor3_states.end(); ++qpts)
-    {
-      Albany::BucketArray<Albany::AbstractSTKFieldContainer::QPTensor3FieldType> array(**qpts, buck);
-      // Debug
-      // std::cout << "Buck.size(): " << buck.size() << " QPT3FT dim[4]: "
-      //           << array.dimension(4) << std::endl;
       Albany::MDArray ar = array;
       stateArrays.elemStateArrays[b][(*qpts)->name()] = ar;
     }

--- a/src/disc/stk/Aeras_SpectralDiscretization.cpp
+++ b/src/disc/stk/Aeras_SpectralDiscretization.cpp
@@ -2685,21 +2685,13 @@ void Aeras::SpectralDiscretization::computeWorksetInfo()
          svs != scalarValue_states.end(); ++svs)
     {
       const int size = 1;
-#ifdef ALBANY_MOR
-      shards::Array<double, shards::NaturalOrder, Cell> array(&time[*svs], size);
-#else
       shards::Array<double, shards::NaturalOrder, Cell> array(&time[**svs], size);
-#endif
-      Albany::MDArray ar = array;
       // Debug
       // std::cout << "Buck.size(): " << buck.size() << " SVState dim[0]: "
       //           << array.dimension(0) << std::endl;
       // std::cout << "SV Name: " << **svs << " address : " << &array << std::endl;
-#ifdef ALBANY_MOR
-      stateArrays.elemStateArrays[b][*svs] = ar;
-#else
+      Albany::MDArray ar = array;
       stateArrays.elemStateArrays[b][**svs] = ar;
-#endif
     }
   }
 

--- a/src/disc/stk/Albany_AbstractSTKFieldContainer.hpp
+++ b/src/disc/stk/Albany_AbstractSTKFieldContainer.hpp
@@ -53,10 +53,6 @@ class AbstractSTKFieldContainer : public AbstractFieldContainer {
     typedef stk::mesh::Field<int, stk::mesh::Cartesian>   IntVectorFieldType ;
 
     typedef stk::mesh::Cartesian QPTag; // need to invent shards::ArrayDimTag
-    // Tensor3 per QP   - (Cell, QP, Dim, Dim, Dim)
-    typedef stk::mesh::Field<double, QPTag, stk::mesh::Cartesian,
-                             stk::mesh::Cartesian,
-                             stk::mesh::Cartesian> QPTensor3FieldType ;
     // Tensor per QP   - (Cell, QP, Dim, Dim)
     typedef stk::mesh::Field<double, QPTag, stk::mesh::Cartesian, stk::mesh::Cartesian> QPTensorFieldType ;
     // Vector per QP   - (Cell, QP, Dim)
@@ -73,7 +69,6 @@ class AbstractSTKFieldContainer : public AbstractFieldContainer {
     typedef std::vector<QPScalarFieldType*> QPScalarState;
     typedef std::vector<QPVectorFieldType*> QPVectorState;
     typedef std::vector<QPTensorFieldType*> QPTensorState;
-    typedef std::vector<QPTensor3FieldType*> QPTensor3State;
 
     typedef std::vector<ScalarFieldType*> ScalarState;
     typedef std::vector<VectorFieldType*> VectorState;
@@ -114,7 +109,6 @@ class AbstractSTKFieldContainer : public AbstractFieldContainer {
     QPScalarState& getQPScalarStates(){return qpscalar_states;}
     QPVectorState& getQPVectorStates(){return qpvector_states;}
     QPTensorState& getQPTensorStates(){return qptensor_states;}
-    QPTensor3State& getQPTensor3States(){return qptensor3_states;}
     const StateInfoStruct& getNodalSIS() const {return nodal_sis;}
     const StateInfoStruct& getNodalParameterSIS() const {return nodal_parameter_sis;}
 
@@ -180,7 +174,6 @@ class AbstractSTKFieldContainer : public AbstractFieldContainer {
     QPScalarState          qpscalar_states;
     QPVectorState          qpvector_states;
     QPTensorState          qptensor_states;
-    QPTensor3State         qptensor3_states;
 
     StateInfoStruct nodal_sis;
     StateInfoStruct nodal_parameter_sis;

--- a/src/disc/stk/Albany_AbstractSTKFieldContainer.hpp
+++ b/src/disc/stk/Albany_AbstractSTKFieldContainer.hpp
@@ -61,11 +61,7 @@ class AbstractSTKFieldContainer : public AbstractFieldContainer {
     typedef stk::mesh::Field<double, QPTag>                      QPScalarFieldType ;
     typedef stk::mesh::Field<double, stk::mesh::Cartesian3d>     SphereVolumeFieldType ;
 
-#ifdef ALBANY_MOR
-    typedef std::vector<std::string> ScalarValueState;  //required to avoid segfault in Albany_RBGen executable
-#else
     typedef std::vector<const std::string*> ScalarValueState;
-#endif
     typedef std::vector<QPScalarFieldType*> QPScalarState;
     typedef std::vector<QPVectorFieldType*> QPVectorState;
     typedef std::vector<QPTensorFieldType*> QPTensorState;

--- a/src/disc/stk/Albany_GenericSTKFieldContainer_Def.hpp
+++ b/src/disc/stk/Albany_GenericSTKFieldContainer_Def.hpp
@@ -71,7 +71,6 @@ Albany::GenericSTKFieldContainer<Interleaved>::addStateStructs(const Teuchos::RC
   typedef typename AbstractSTKFieldContainer::QPScalarFieldType QPSFT;
   typedef typename AbstractSTKFieldContainer::QPVectorFieldType QPVFT;
   typedef typename AbstractSTKFieldContainer::QPTensorFieldType QPTFT;
-  typedef typename AbstractSTKFieldContainer::QPTensor3FieldType QPT3FT;
   typedef typename AbstractSTKFieldContainer::ScalarFieldType SFT;
   typedef typename AbstractSTKFieldContainer::VectorFieldType VFT;
   typedef typename AbstractSTKFieldContainer::TensorFieldType TFT;
@@ -87,7 +86,7 @@ Albany::GenericSTKFieldContainer<Interleaved>::addStateStructs(const Teuchos::RC
       {
         // Scalar on cell
         cell_scalar_states.push_back(& metaData->declare_field< SFT >(stk::topology::ELEMENT_RANK, st.name));
-        stk::mesh::put_field(*cell_scalar_states.back(), metaData->universal_part(), 1);
+        stk::mesh::put_field_on_mesh(*cell_scalar_states.back(), metaData->universal_part(), 1, nullptr);
 #ifdef ALBANY_SEACAS
         stk::io::set_field_role(*cell_scalar_states.back(), role_type(st.output));
 #endif
@@ -96,7 +95,7 @@ Albany::GenericSTKFieldContainer<Interleaved>::addStateStructs(const Teuchos::RC
       {
         // Vector on cell
         cell_vector_states.push_back(& metaData->declare_field< VFT >(stk::topology::ELEMENT_RANK, st.name));
-        stk::mesh::put_field(*cell_vector_states.back(), metaData->universal_part(), dim[1]);
+        stk::mesh::put_field_on_mesh(*cell_vector_states.back(), metaData->universal_part(), dim[1], nullptr);
 #ifdef ALBANY_SEACAS
         stk::io::set_field_role(*cell_vector_states.back(), role_type(st.output));
 #endif
@@ -105,7 +104,7 @@ Albany::GenericSTKFieldContainer<Interleaved>::addStateStructs(const Teuchos::RC
       {
         // 2nd order tensor on cell
         cell_tensor_states.push_back(& metaData->declare_field< TFT >(stk::topology::ELEMENT_RANK, st.name));
-        stk::mesh::put_field(*cell_tensor_states.back(), metaData->universal_part(), dim[2], dim[1]);
+        stk::mesh::put_field_on_mesh(*cell_tensor_states.back(), metaData->universal_part(), dim[2], dim[1], nullptr);
 #ifdef ALBANY_SEACAS
         stk::io::set_field_role(*cell_tensor_states.back(), role_type(st.output));
 #endif
@@ -122,7 +121,7 @@ Albany::GenericSTKFieldContainer<Interleaved>::addStateStructs(const Teuchos::RC
 
         if(dim.size() == 2){ // Scalar at QPs
           qpscalar_states.push_back(& metaData->declare_field< QPSFT >(stk::topology::ELEMENT_RANK, st.name));
-          stk::mesh::put_field(*qpscalar_states.back(), metaData->universal_part(), dim[1]);
+          stk::mesh::put_field_on_mesh(*qpscalar_states.back(), metaData->universal_part(), dim[1], nullptr);
         //Debug
         //      cout << "Allocating qps field name " << qpscalar_states.back()->name() <<
         //            " size: (" << dim[0] << ", " << dim[1] << ")" <<endl;
@@ -133,7 +132,7 @@ Albany::GenericSTKFieldContainer<Interleaved>::addStateStructs(const Teuchos::RC
         else if(dim.size() == 3){ // Vector at QPs
           qpvector_states.push_back(& metaData->declare_field< QPVFT >(stk::topology::ELEMENT_RANK, st.name));
           // Multi-dim order is Fortran Ordering, so reversed here
-          stk::mesh::put_field(*qpvector_states.back(), metaData->universal_part(), dim[2], dim[1]);
+          stk::mesh::put_field_on_mesh(*qpvector_states.back(), metaData->universal_part(), dim[2], dim[1], nullptr);
           //Debug
           //      cout << "Allocating qpv field name " << qpvector_states.back()->name() <<
           //            " size: (" << dim[0] << ", " << dim[1] << ", " << dim[2] << ")" <<endl;
@@ -144,8 +143,8 @@ Albany::GenericSTKFieldContainer<Interleaved>::addStateStructs(const Teuchos::RC
         else if(dim.size() == 4){ // Tensor at QPs
           qptensor_states.push_back(& metaData->declare_field< QPTFT >(stk::topology::ELEMENT_RANK, st.name));
           // Multi-dim order is Fortran Ordering, so reversed here
-          stk::mesh::put_field(*qptensor_states.back() ,
-                           metaData->universal_part(), dim[3], dim[2], dim[1]);
+          stk::mesh::put_field_on_mesh(*qptensor_states.back() ,
+                           metaData->universal_part(), dim[3], dim[2], dim[1], nullptr);
           //Debug
           //      cout << "Allocating qpt field name " << qptensor_states.back()->name() <<
           //            " size: (" << dim[0] << ", " << dim[1] << ", " << dim[2] << ", " << dim[3] << ")" <<endl;
@@ -153,18 +152,7 @@ Albany::GenericSTKFieldContainer<Interleaved>::addStateStructs(const Teuchos::RC
           stk::io::set_field_role(*qptensor_states.back(), role_type(st.output));
 #endif
         }
-        else if(dim.size() == 5){ // Tensor3 at QPs
-          qptensor3_states.push_back(& metaData->declare_field< QPT3FT >(stk::topology::ELEMENT_RANK, st.name));
-          // Multi-dim order is Fortran Ordering, so reversed here
-          stk::mesh::put_field(*qptensor3_states.back(), metaData->universal_part(), dim[4], dim[3], dim[2], dim[1]);
-          //Debug
-          //      cout << "Allocating qpt field name " << qptensor_states.back()->name() <<
-          //            " size: (" << dim[0] << ", " << dim[1] << ", " << dim[2] << ", " << dim[3] << ", " << dim[4] << ")" <<endl;
-#ifdef ALBANY_SEACAS
-          stk::io::set_field_role(*qptensor3_states.back(), role_type(st.output));
-#endif
-        }
-        // Something other than a scalar, vector, tensor, or tensor3 at the QPs is an error
+        // Something other than a scalar, vector, or tensor
         else TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
             "Error: GenericSTKFieldContainer - cannot match QPData");
     } // end QuadPoint
@@ -812,7 +800,6 @@ Albany::GenericSTKFieldContainer<Interleaved>::copySTKField(const T* source, T* 
     const int num_target_components = target_array.dimension(0);
     const int num_nodes_in_bucket = source_array.dimension(1);
 
-    int downsample = num_source_components / num_target_components;
     int uneven_downsampling = num_source_components % num_target_components;
 
     TEUCHOS_TEST_FOR_EXCEPTION((uneven_downsampling) ||

--- a/src/disc/stk/Albany_GenericSTKFieldContainer_Def.hpp
+++ b/src/disc/stk/Albany_GenericSTKFieldContainer_Def.hpp
@@ -158,11 +158,7 @@ Albany::GenericSTKFieldContainer<Interleaved>::addStateStructs(const Teuchos::RC
     } // end QuadPoint
     // Single scalar at center of the workset
     else if(dim.size() == 1 && st.entity == StateStruct::WorksetValue) { // A single value that applies over the entire workset (time)
-#ifdef ALBANY_MOR
-      scalarValue_states.push_back(st.name); // Albany_RBGen requires the name, not the pointer, to avoid a segfault
-#else
       scalarValue_states.push_back(&st.name); // Just save a pointer to the name allocated in st
-#endif
     } // End scalar at center of element
     else if((st.entity == StateStruct::NodalData) ||(st.entity == StateStruct::NodalDataToElemNode) || (st.entity == StateStruct::NodalDistParameter))
     { // Data at the node points

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -861,7 +861,7 @@ void Albany::GenericSTKMeshStruct::initializeSideSetMeshStructs (const Teuchos::
       // We need to create the 2D cell -> (3D cell, side_node_ids) map in the side mesh now
       typedef AbstractSTKFieldContainer::IntScalarFieldType ISFT;
       ISFT* side_to_cell_map = &this->sideSetMeshStructs[ss_name]->metaData->declare_field<ISFT> (stk::topology::ELEM_RANK, "side_to_cell_map");
-      stk::mesh::put_field(*side_to_cell_map, this->sideSetMeshStructs[ss_name]->metaData->universal_part(), 1);
+      stk::mesh::put_field_on_mesh(*side_to_cell_map, this->sideSetMeshStructs[ss_name]->metaData->universal_part(), 1, nullptr);
 #ifdef ALBANY_SEACAS
       stk::io::set_field_role(*side_to_cell_map, Ioss::Field::TRANSIENT);
 #endif
@@ -869,7 +869,7 @@ void Albany::GenericSTKMeshStruct::initializeSideSetMeshStructs (const Teuchos::
       const int num_nodes = sideSetMeshStructs[ss_name]->getMeshSpecs()[0]->ctd.node_count;
       typedef AbstractSTKFieldContainer::IntVectorFieldType IVFT;
       IVFT* side_nodes_ids = &this->sideSetMeshStructs[ss_name]->metaData->declare_field<IVFT> (stk::topology::ELEM_RANK, "side_nodes_ids");
-      stk::mesh::put_field(*side_nodes_ids, this->sideSetMeshStructs[ss_name]->metaData->universal_part(), num_nodes);
+      stk::mesh::put_field_on_mesh(*side_nodes_ids, this->sideSetMeshStructs[ss_name]->metaData->universal_part(), num_nodes, nullptr);
 #ifdef ALBANY_SEACAS
       stk::io::set_field_role(*side_nodes_ids, Ioss::Field::TRANSIENT);
 #endif

--- a/src/disc/stk/Albany_IossSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_IossSTKMeshStruct.cpp
@@ -121,7 +121,7 @@ Albany::IossSTKMeshStruct::IossSTKMeshStruct(
     if (!stk::io::is_part_io_part(newNodeSet)) {
       stk::mesh::Field<double> * const distrFactorfield = metaData->get_field<stk::mesh::Field<double> >(stk::topology::NODE_RANK, "distribution_factors");
       if (distrFactorfield != NULL){
-        stk::mesh::put_field(*distrFactorfield, newNodeSet);
+        stk::mesh::put_field_on_mesh(*distrFactorfield, newNodeSet, nullptr);
       }
       stk::io::put_io_part_attribute(newNodeSet);
     }

--- a/src/disc/stk/Albany_MultiSTKFieldContainer_Def.hpp
+++ b/src/disc/stk/Albany_MultiSTKFieldContainer_Def.hpp
@@ -69,7 +69,7 @@ Albany::MultiSTKFieldContainer<Interleaved>::MultiSTKFieldContainer(
 
       std::string name = params_->get<std::string>(sol_tag_name[vec_num], sol_id_name[vec_num]);
       VFT* solution = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK, name);
-      stk::mesh::put_field(*solution, metaData_->universal_part(), neq_);
+      stk::mesh::put_field_on_mesh(*solution, metaData_->universal_part(), neq_, nullptr);
 #ifdef ALBANY_SEACAS
       stk::io::set_field_role(*solution, Ioss::Field::TRANSIENT);
 #endif
@@ -82,7 +82,7 @@ Albany::MultiSTKFieldContainer<Interleaved>::MultiSTKFieldContainer(
     else if(solution_vector[vec_num].size() == 1) { // User is just renaming the entire solution vector
 
       VFT* solution = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK, solution_vector[vec_num][0]);
-      stk::mesh::put_field(*solution, metaData_->universal_part(), neq_);
+      stk::mesh::put_field_on_mesh(*solution, metaData_->universal_part(), neq_, nullptr);
 #ifdef ALBANY_SEACAS
       stk::io::set_field_role(*solution, Ioss::Field::TRANSIENT);
 #endif
@@ -108,7 +108,7 @@ Albany::MultiSTKFieldContainer<Interleaved>::MultiSTKFieldContainer(
           len = numDim_; // vector
           accum += len;
           VFT* solution = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK, solution_vector[vec_num][i]);
-          stk::mesh::put_field(*solution, metaData_->universal_part(), len);
+          stk::mesh::put_field_on_mesh(*solution, metaData_->universal_part(), len, nullptr);
 #ifdef ALBANY_SEACAS
           stk::io::set_field_role(*solution, Ioss::Field::TRANSIENT);
 #endif
@@ -122,7 +122,7 @@ Albany::MultiSTKFieldContainer<Interleaved>::MultiSTKFieldContainer(
           len = 1; // scalar
           accum += len;
           SFT* solution = & metaData_->declare_field< SFT >(stk::topology::NODE_RANK, solution_vector[vec_num][i]);
-          stk::mesh::put_field(*solution, metaData_->universal_part());
+          stk::mesh::put_field_on_mesh(*solution, metaData_->universal_part(), nullptr);
 #ifdef ALBANY_SEACAS
           stk::io::set_field_role(*solution, Ioss::Field::TRANSIENT);
 #endif
@@ -151,7 +151,7 @@ Albany::MultiSTKFieldContainer<Interleaved>::MultiSTKFieldContainer(
 
     std::string name = params_->get<std::string>(res_tag_name, res_id_name);
     VFT* residual = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK, name);
-    stk::mesh::put_field(*residual, metaData_->universal_part(), neq_);
+    stk::mesh::put_field_on_mesh(*residual, metaData_->universal_part(), neq_, nullptr);
 #ifdef ALBANY_SEACAS
     stk::io::set_field_role(*residual, Ioss::Field::TRANSIENT);
 #endif
@@ -164,7 +164,7 @@ Albany::MultiSTKFieldContainer<Interleaved>::MultiSTKFieldContainer(
   else if(residual_vector.size() == 1) { // User is just renaming the entire residual vector
 
     VFT* residual = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK, residual_vector[0]);
-    stk::mesh::put_field(*residual, metaData_->universal_part(), neq_);
+    stk::mesh::put_field_on_mesh(*residual, metaData_->universal_part(), neq_, nullptr);
 #ifdef ALBANY_SEACAS
     stk::io::set_field_role(*residual, Ioss::Field::TRANSIENT);
 #endif
@@ -190,7 +190,7 @@ Albany::MultiSTKFieldContainer<Interleaved>::MultiSTKFieldContainer(
         len = numDim_; // vector
         accum += len;
         VFT* residual = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK, residual_vector[i]);
-        stk::mesh::put_field(*residual, metaData_->universal_part(), len);
+        stk::mesh::put_field_on_mesh(*residual, metaData_->universal_part(), len, nullptr);
 #ifdef ALBANY_SEACAS
         stk::io::set_field_role(*residual, Ioss::Field::TRANSIENT);
 #endif
@@ -204,7 +204,7 @@ Albany::MultiSTKFieldContainer<Interleaved>::MultiSTKFieldContainer(
         len = 1; // scalar
         accum += len;
         SFT* residual = & metaData_->declare_field< SFT >(stk::topology::NODE_RANK, residual_vector[i]);
-        stk::mesh::put_field(*residual, metaData_->universal_part());
+        stk::mesh::put_field_on_mesh(*residual, metaData_->universal_part(), nullptr);
 #ifdef ALBANY_SEACAS
         stk::io::set_field_role(*residual, Ioss::Field::TRANSIENT);
 #endif
@@ -231,7 +231,7 @@ Albany::MultiSTKFieldContainer<Interleaved>::MultiSTKFieldContainer(
 
   //Do the coordinates
   this->coordinates_field = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK, "coordinates");
-  stk::mesh::put_field(*this->coordinates_field , metaData_->universal_part(), numDim_);
+  stk::mesh::put_field_on_mesh(*this->coordinates_field , metaData_->universal_part(), numDim_, nullptr);
 #ifdef ALBANY_SEACAS
   stk::io::set_field_role(*this->coordinates_field, Ioss::Field::MESH);
 #endif
@@ -243,7 +243,7 @@ Albany::MultiSTKFieldContainer<Interleaved>::MultiSTKFieldContainer(
   else
   {
     this->coordinates_field3d = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK, "coordinates3d");
-    stk::mesh::put_field(*this->coordinates_field3d , metaData_->universal_part(), 3);
+    stk::mesh::put_field_on_mesh(*this->coordinates_field3d , metaData_->universal_part(), 3, nullptr);
 #ifdef ALBANY_SEACAS
     stk::io::set_field_role(*this->coordinates_field3d, Ioss::Field::MESH);
 #endif
@@ -290,13 +290,15 @@ void Albany::MultiSTKFieldContainer<Interleaved>::initializeSTKAdaptation() {
     & this->metaData->template declare_field< ISFT >(stk::topology::ELEMENT_RANK, "refine_field");
 
   // Processor rank field, a scalar
-  stk::mesh::put_field(
+  stk::mesh::put_field_on_mesh(
       *this->proc_rank_field,
-      this->metaData->universal_part());
+      this->metaData->universal_part(),
+      nullptr);
 
-  stk::mesh::put_field(
+  stk::mesh::put_field_on_mesh(
       *this->refine_field,
-      this->metaData->universal_part());
+      this->metaData->universal_part(),
+      nullptr);
 
 #if defined(ALBANY_LCM)
   // Fracture state used for adaptive insertion.
@@ -304,10 +306,10 @@ void Albany::MultiSTKFieldContainer<Interleaved>::initializeSTKAdaptation() {
 
   for (stk::mesh::EntityRank rank = stk::topology::NODE_RANK; rank < stk::topology::ELEMENT_RANK; ++rank) {
     this->fracture_state[rank] = &this->metaData->template declare_field< ISFT >(rank, "fracture_state");
-    stk::mesh::put_field(
+    stk::mesh::put_field_on_mesh(
         *this->fracture_state[rank],
-        this->metaData->universal_part());
-
+        this->metaData->universal_part(),
+        nullptr);
   }
 #endif // ALBANY_LCM
 

--- a/src/disc/stk/Albany_OrdinarySTKFieldContainer_Def.hpp
+++ b/src/disc/stk/Albany_OrdinarySTKFieldContainer_Def.hpp
@@ -75,7 +75,7 @@ Albany::OrdinarySTKFieldContainer<Interleaved>::OrdinarySTKFieldContainer(
  
   //Start STK stuff
   this->coordinates_field = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK, "coordinates");
-  stk::mesh::put_field(*this->coordinates_field , metaData_->universal_part(), numDim_);
+  stk::mesh::put_field_on_mesh(*this->coordinates_field , metaData_->universal_part(), numDim_, nullptr);
 #ifdef ALBANY_SEACAS
   stk::io::set_field_role(*this->coordinates_field, Ioss::Field::MESH);
 #endif
@@ -86,7 +86,7 @@ Albany::OrdinarySTKFieldContainer<Interleaved>::OrdinarySTKFieldContainer(
   else
   {
     this->coordinates_field3d = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK, "coordinates3d");
-    stk::mesh::put_field(*this->coordinates_field3d , metaData_->universal_part(), 3);
+    stk::mesh::put_field_on_mesh(*this->coordinates_field3d , metaData_->universal_part(), 3, nullptr);
 #ifdef ALBANY_SEACAS
     stk::io::set_field_role(*this->coordinates_field3d, Ioss::Field::MESH);
 #endif
@@ -100,13 +100,13 @@ Albany::OrdinarySTKFieldContainer<Interleaved>::OrdinarySTKFieldContainer(
     solution_field[num_vecs] = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK,
                                     params_->get<std::string>(sol_tag_name[num_vecs], sol_id_name[num_vecs]));
 
-    stk::mesh::put_field(*solution_field[num_vecs] , metaData_->universal_part(), neq_);
+    stk::mesh::put_field_on_mesh(*solution_field[num_vecs] , metaData_->universal_part(), neq_, nullptr);
 
 #if defined(ALBANY_DTK)
     if (output_dtk_field == true) { 
       solution_field_dtk[num_vecs] = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK,
                                       params_->get<std::string>(sol_dtk_tag_name[num_vecs], sol_dtk_id_name[num_vecs]));
-      stk::mesh::put_field(*solution_field_dtk[num_vecs] , metaData_->universal_part() , neq_);
+      stk::mesh::put_field_on_mesh(*solution_field_dtk[num_vecs] , metaData_->universal_part() , neq_, nullptr);
    }
 #endif
 
@@ -123,7 +123,7 @@ Albany::OrdinarySTKFieldContainer<Interleaved>::OrdinarySTKFieldContainer(
 #if defined(ALBANY_LCM)
   residual_field = & metaData_->declare_field< VFT >(stk::topology::NODE_RANK,
                                     params_->get<std::string>(res_tag_name[0], res_id_name[0]));
-  stk::mesh::put_field(*residual_field, metaData_->universal_part() , neq_);
+  stk::mesh::put_field_on_mesh(*residual_field, metaData_->universal_part() , neq_, nullptr);
 #ifdef ALBANY_SEACAS
   stk::io::set_field_role(*residual_field, Ioss::Field::TRANSIENT);
 #endif
@@ -167,13 +167,15 @@ void Albany::OrdinarySTKFieldContainer<Interleaved>::initializeSTKAdaptation() {
     & this->metaData->template declare_field< ISFT >(stk::topology::ELEMENT_RANK, "refine_field");
 
   // Processor rank field, a scalar
-  stk::mesh::put_field(
+  stk::mesh::put_field_on_mesh(
       *this->proc_rank_field,
-      this->metaData->universal_part());
+      this->metaData->universal_part(),
+      nullptr);
 
-  stk::mesh::put_field(
+  stk::mesh::put_field_on_mesh(
       *this->refine_field,
-      this->metaData->universal_part());
+      this->metaData->universal_part(),
+      nullptr);
 
 #if defined(ALBANY_LCM)
   // Fracture state used for adaptive insertion.
@@ -181,10 +183,10 @@ void Albany::OrdinarySTKFieldContainer<Interleaved>::initializeSTKAdaptation() {
   for (stk::mesh::EntityRank rank = stk::topology::NODE_RANK; rank < stk::topology::ELEMENT_RANK; ++rank) {
     this->fracture_state[rank] = & this->metaData->template declare_field< ISFT >(rank, "fracture_state");
 
-    stk::mesh::put_field(
+    stk::mesh::put_field_on_mesh(
         *this->fracture_state[rank],
-        this->metaData->universal_part());
-
+        this->metaData->universal_part(),
+        nullptr);
   }
 #endif // ALBANY_LCM
 

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -2256,7 +2256,6 @@ Albany::STKDiscretization::computeWorksetInfo()
   typedef Albany::AbstractSTKFieldContainer::QPScalarState    QPScalarState;
   typedef Albany::AbstractSTKFieldContainer::QPVectorState    QPVectorState;
   typedef Albany::AbstractSTKFieldContainer::QPTensorState    QPTensorState;
-  typedef Albany::AbstractSTKFieldContainer::QPTensor3State   QPTensor3State;
 
   typedef Albany::AbstractSTKFieldContainer::ScalarState ScalarState;
   typedef Albany::AbstractSTKFieldContainer::VectorState VectorState;
@@ -2275,7 +2274,6 @@ Albany::STKDiscretization::computeWorksetInfo()
   QPScalarState&    qpscalar_states    = container.getQPScalarStates();
   QPVectorState&    qpvector_states    = container.getQPVectorStates();
   QPTensorState&    qptensor_states    = container.getQPTensorStates();
-  QPTensor3State&   qptensor3_states   = container.getQPTensor3States();
   std::map<std::string, double>& time = container.getTime();
 
   for (std::size_t b = 0; b < buckets.size(); b++) {
@@ -2337,16 +2335,6 @@ Albany::STKDiscretization::computeWorksetInfo()
       // Debug
       // std::cout << "Buck.size(): " << buck.size() << " QPTFT dim[3]: " <<
       // array.dimension(3) << std::endl;
-      MDArray ar                                      = array;
-      stateArrays.elemStateArrays[b][(*qpts)->name()] = ar;
-    }
-    for (auto qpts = qptensor3_states.begin(); qpts != qptensor3_states.end();
-         ++qpts) {
-      BucketArray<Albany::AbstractSTKFieldContainer::QPTensor3FieldType> array(
-          **qpts, buck);
-      // Debug
-      // std::cout << "Buck.size(): " << buck.size() << " QPT3FT dim[4]: " <<
-      // array.dimension(4) << std::endl;
       MDArray ar                                      = array;
       stateArrays.elemStateArrays[b][(*qpts)->name()] = ar;
     }

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -2338,24 +2338,6 @@ Albany::STKDiscretization::computeWorksetInfo()
       MDArray ar                                      = array;
       stateArrays.elemStateArrays[b][(*qpts)->name()] = ar;
     }
-#ifdef ALBANY_MOR
-    // AlbanyRBGen requires scalarValue_states to contain a string, not a
-    // pointer to a string, in order to avoid a seqfault
-    for (ScalarValueState::iterator svs = scalarValue_states.begin();
-         svs != scalarValue_states.end();
-         ++svs) {
-      const int size = 1;
-      shards::Array<double, shards::NaturalOrder, Cell> array(
-          &time[*svs], size);
-      MDArray ar = array;
-      // Debug
-      // std::cout << "Buck.size(): " << buck.size() << " SVState dim[0]: " <<
-      // array.dimension(0) << std::endl;
-      // std::cout << "SV Name: " << *svs << " address : " << &array <<
-      // std::endl;
-      stateArrays.elemStateArrays[b][*svs] = ar;
-    }
-#else
     //    for (ScalarValueState::iterator svs = scalarValue_states.begin();
     //              svs != scalarValue_states.end(); ++svs){
     for (int i = 0; i < scalarValue_states.size(); i++) {
@@ -2370,7 +2352,6 @@ Albany::STKDiscretization::computeWorksetInfo()
       // std::endl;
       stateArrays.elemStateArrays[b][*scalarValue_states[i]] = ar;
     }
-#endif
   }
 
   // Process node data sets if present

--- a/src/disc/stk/Albany_STKNodeFieldContainer.hpp
+++ b/src/disc/stk/Albany_STKNodeFieldContainer.hpp
@@ -89,12 +89,12 @@ buildSTKNodeField(const std::string& name, const std::vector<PHX::DataLayout::si
 
     enum { size = 1 }; // One array dimension tag (Node), store type T values
     typedef stk::mesh::Field<T> field_type ;
-    static field_type* createField(const std::string& name, const std::vector<PHX::DataLayout::size_type>& dim,
+    static field_type* createField(const std::string& name, const std::vector<PHX::DataLayout::size_type>& /* dim */,
                                    stk::mesh::MetaData* metaData){
 
         field_type *fld = & metaData->declare_field<field_type>(stk::topology::NODE_RANK, name);
         // Multi-dim order is Fortran Ordering, so reversed here
-        stk::mesh::put_field(*fld , metaData->universal_part());
+        stk::mesh::put_field_on_mesh(*fld , metaData->universal_part(), nullptr);
 
         return fld; // Address is held by stk
 
@@ -137,7 +137,7 @@ buildSTKNodeField(const std::string& name, const std::vector<PHX::DataLayout::si
 
         field_type *fld = & metaData->declare_field<field_type>(stk::topology::NODE_RANK, name);
         // Multi-dim order is Fortran Ordering, so reversed here
-        stk::mesh::put_field(*fld , metaData->universal_part(), dim[1]);
+        stk::mesh::put_field_on_mesh(*fld , metaData->universal_part(), dim[1], nullptr);
 
         return fld; // Address is held by stk
 
@@ -186,7 +186,7 @@ buildSTKNodeField(const std::string& name, const std::vector<PHX::DataLayout::si
 
         field_type *fld = & metaData->declare_field<field_type>(stk::topology::NODE_RANK, name);
         // Multi-dim order is Fortran Ordering, so reversed here
-        stk::mesh::put_field(*fld , metaData->universal_part(), dim[2], dim[1]);
+        stk::mesh::put_field_on_mesh(*fld , metaData->universal_part(), dim[2], dim[1], nullptr);
 
         return fld; // Address is held by stk
 


### PR DESCRIPTION
This PR takes care of issue #372 (plus it removes some leftover code that depended on `ALBANY_MOR` being defined).

Besides changing deprecated function names to non-deprecated ones, this PR also *removes* the field type `QPTensor3FieldType` from the STK discretizations structures. This is because the new implementation of the deprecated function in STK is only present for fields up to 3 dimensions (per entity), so the maximum we can add to the mesh is a 2d tensor per QP or Node (within an element) or a 3d tensor per Cell.