### PR TITLE
Extruded sides

### DIFF
--- a/src/LandIce/evaluators/LandIce_GatherVerticallyAveragedVelocity.hpp
+++ b/src/LandIce/evaluators/LandIce_GatherVerticallyAveragedVelocity.hpp
@@ -44,7 +44,7 @@ protected:
   typedef typename EvalT::ScalarT ScalarT;
 
   // Output:
-  PHX::MDField<ScalarT,Cell,Node,VecDim>  averagedVel;
+  PHX::MDField<ScalarT,Side,Cell,Node,VecDim>  averagedVel;
 
   std::size_t vecDimFO;
   std::size_t numNodes;

--- a/src/LandIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
@@ -87,7 +87,7 @@ ResponseSMBMismatch(Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layout
   PHX::Tag<ScalarT> global_response_tag(global_response_name, global_response_layout);
   p.set("Local Response Field Tag", local_response_tag);
   p.set("Global Response Field Tag", global_response_tag);
-  PHAL::SeparableScatterScalarResponse<EvalT, Traits>::setup(p, dl_basal);
+  PHAL::SeparableScatterScalarResponse<EvalT, Traits>::setup(p, dl);
 }
 
 // **********************************************************************

--- a/src/LandIce/evaluators/LandIce_ScatterResidual2D_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ScatterResidual2D_Def.hpp
@@ -33,13 +33,8 @@ ScatterResidual2D(const Teuchos::ParameterList& p,
     numFields(ScatterResidual<PHAL::AlbanyTraits::Jacobian,Traits>::numFieldsBase)
 {
   cell_topo = p.get<Teuchos::RCP<const CellTopologyData> >("Cell Topology");
-  if (p.isType<int>("Field Level"))
-    fieldLevel = p.get<int>("Field Level");
-  else fieldLevel = -1;
-  if (p.isType<const std::string>("Mesh Part"))
-    meshPart = p.get<const std::string>("Mesh Part");
-  else
-    meshPart = "upperside";
+  fieldLevel = p.get<int>("Field Level");
+  meshPart = p.get<std::string>("Mesh Part");
 }
 
 // **********************************************************************
@@ -60,7 +55,6 @@ evaluateFields(typename Traits::EvalData workset)
   const Albany::NodalDOFManager& solDOFManager = workset.disc->getOverlapDOFManager("ordinary_solution");
   const Albany::LayeredMeshNumbering<LO>& layeredMeshNumbering = *workset.disc->getLayeredMeshNumbering();
   int numLayers = layeredMeshNumbering.numLayers;
-  fieldLevel = (fieldLevel < 0) ? numLayers : fieldLevel;
   colT.reserve(neq*this->numNodes*(numLayers+1));
 
   const Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO> >& wsElNodeID  = workset.disc->getWsElNodeID()[workset.wsIndex];
@@ -172,9 +166,7 @@ ScatterResidualWithExtrudedField(const Teuchos::ParameterList& p,
   if (p.isType<int>("Offset 2D Field"))
     offset2DField = p.get<int>("Offset 2D Field");
   else offset2DField = numFields-1;
-  if (p.isType<int>("Field Level"))
-    fieldLevel = p.get<int>("Field Level");
-  else fieldLevel = -1;
+  fieldLevel = p.get<int>("Field Level");
 }
 
 // **********************************************************************
@@ -240,7 +232,6 @@ evaluateFields(typename Traits::EvalData workset)
   const Albany::NodalDOFManager& solDOFManager = workset.disc->getOverlapDOFManager("ordinary_solution");
   const Albany::LayeredMeshNumbering<LO>& layeredMeshNumbering = *workset.disc->getLayeredMeshNumbering();
   int numLayers = layeredMeshNumbering.numLayers;
-  fieldLevel = (fieldLevel < 0) ? numLayers : fieldLevel;
   colT.resize(this->numNodes);
 
   const Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO> >& wsElNodeID  = workset.disc->getWsElNodeID()[workset.wsIndex];

--- a/src/LandIce/evaluators/LandIce_ThicknessResid.hpp
+++ b/src/LandIce/evaluators/LandIce_ThicknessResid.hpp
@@ -49,7 +49,7 @@ private:
 
   PHX::MDField<const ScalarT,Cell,Node> dH;
   PHX::MDField<const ParamScalarT,Cell,Node> H0;
-  PHX::MDField<const ScalarT,Cell,Node,Dim> V;
+  PHX::MDField<const ScalarT,Side,Cell,Node,Dim> V;
   PHX::MDField<const ParamScalarT,Cell,Node> SMB;
   PHX::MDField<const MeshScalarT,Cell,Vertex,Dim> coordVec;
   
@@ -57,12 +57,11 @@ private:
   PHX::MDField<ScalarT,Cell,Node> Residual;
 
 
-  int  cellDims, sideDims, numQPsSide, numNodes, cubatureDegree;
+  int  cellDims, numNodes, cubatureDegree;
   Teuchos::RCP<double> dt;
   bool have_SMB;
   std::string meshPart;
 
-  std::size_t numQPs;
   std::size_t numVecFODims;
 
 

--- a/src/LandIce/evaluators/LandIce_UpdateZCoordinate.hpp
+++ b/src/LandIce/evaluators/LandIce_UpdateZCoordinate.hpp
@@ -42,14 +42,17 @@ private:
 
   // Input:
   PHX::MDField<const MeshScalarT, Cell, Node,Dim> coordVecIn;
-  PHX::MDField<const MeshScalarT, Cell, Node> dH;
-  PHX::MDField<const MeshScalarT, Cell, Node> topSurface;
+  PHX::MDField<const MeshScalarT, Cell, Node> bedTopo;
+  PHX::MDField<const MeshScalarT, Cell, Node> H;
   PHX::MDField<const MeshScalarT, Cell, Node> H0;
+  PHX::MDField<const MeshScalarT, Cell, Node> dH;
+  PHX::MDField<MeshScalarT, Cell, Node> topSurface;
 
   // Output:
   PHX::MDField<MeshScalarT, Cell, Node, Dim> coordVecOut;
 
-  double minH;
+  bool haveThickness;
+  double minH, rho_i, rho_w;
   unsigned int numDims, numNodes;
 };
 

--- a/src/LandIce/problems/LandIce_Hydrology.hpp
+++ b/src/LandIce/problems/LandIce_Hydrology.hpp
@@ -892,12 +892,12 @@ Hydrology::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
   //--- Shared Parameter for basal friction coefficient: mu ---//
   p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: mu"));
 
-  param_name = ParamEnumName::Mu;
+  param_name = ParamEnumName::MuCoulomb;
   p->set<std::string>("Parameter Name", param_name);
   p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
 
-  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Mu>> ptr_mu;
-  ptr_mu = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Mu>(*p,dl));
+  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuCoulomb>> ptr_mu;
+  ptr_mu = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuCoulomb>(*p,dl));
   ptr_mu->setNominalValue(params->sublist("Parameters"),params->sublist("LandIce Basal Friction Coefficient").get<double>(param_name,-1.0));
   fm0.template registerEvaluator<EvalT>(ptr_mu);
 

--- a/src/LandIce/problems/LandIce_ParamEnum.hpp
+++ b/src/LandIce/problems/LandIce_ParamEnum.hpp
@@ -10,16 +10,18 @@ enum class ParamEnum
 {
   Alpha        = 0,
   Lambda       = 1,
-  Mu           = 2,
-  Power        = 3,
-  Homotopy     = 4
+  MuCoulomb    = 2,
+  MuPowerLaw   = 3,
+  Power        = 4,
+  Homotopy     = 5
 };
 
 namespace ParamEnumName
 {
   static const std::string Alpha         = "Hydraulic-Over-Hydrostatic Potential Ratio";
   static const std::string Lambda        = "Bed Roughness";
-  static const std::string Mu            = "Coulomb Friction Coefficient";
+  static const std::string MuCoulomb     = "Coulomb Friction Coefficient";
+  static const std::string MuPowerLaw    = "Power Law Coefficient";
   static const std::string Power         = "Power Exponent";
   static const std::string HomotopyParam = "Homotopy Parameter";
 } // ParamEnum

--- a/src/LandIce/problems/LandIce_SchoofFit.hpp
+++ b/src/LandIce/problems/LandIce_SchoofFit.hpp
@@ -368,8 +368,8 @@ LandIce::SchoofFit::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& 
   p->set<std::string>("Parameter Name", param_name);
   p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
 
-  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Mu>> ptr_mu;
-  ptr_mu = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Mu>(*p,dl));
+  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuCoulomb>> ptr_mu;
+  ptr_mu = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuCoulomb>(*p,dl));
   ptr_mu->setNominalValue(params->sublist("Parameters"),params->sublist("LandIce Basal Friction Coefficient").get<double>(param_name,-1.0));
   fm0.template registerEvaluator<EvalT>(ptr_mu);
 

--- a/src/LandIce/problems/LandIce_StokesFOBase.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.cpp
@@ -222,6 +222,8 @@ LandIce::StokesFOBase::getStokesFOBaseProblemParameters () const
   validPL->sublist("LandIce Noise", false, "");
   validPL->set<bool>("Use Time Parameter", false, "Solely to use Solver Method = Continuation");
   validPL->set<bool>("Print Stress Tensor", false, "Whether to save stress tensor in the mesh");
+  validPL->set<bool>("Adjust Bed Topography to Account for Thickness Changes", false, "");
+  validPL->set<bool>("Adjust Surface Height to Account for Thickness Changes", false, "");
 
   return validPL;
 }

--- a/src/LandIce/problems/LandIce_StokesFOBase.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.hpp
@@ -1410,10 +1410,6 @@ void StokesFOBase::constructSMBEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>
     ev = evalUtils.getPSTUtils().constructDOFInterpolationSideEvaluator("observed_ice_thickness_RMS_" + basalSideName, basalSideName, enableMemoizer);
     fm0.template registerEvaluator<EvalT>(ev);
 
-    // Interpolate the 3D state on the side (the BasalFrictionCoefficient evaluator needs a side field)
-    ev = evalUtils.constructDOFCellToSideEvaluator("Averaged Velocity",basalSideName,"Node Vector",cellType);
-    fm0.template registerEvaluator<EvalT> (ev);
-
     //---- Interpolate velocity on QP on side
     ev = evalUtils.constructDOFVecInterpolationSideEvaluator("Averaged Velocity", basalSideName);
     fm0.template registerEvaluator<EvalT>(ev);
@@ -1444,6 +1440,7 @@ void StokesFOBase::constructSMBEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>
 
     p->set<std::string>("Averaged Velocity Name", "Averaged Velocity");
     p->set<std::string>("Mesh Part", "basalside");
+    p->set<std::string>("Side Set Name", basalSideName);
     p->set<Teuchos::RCP<const CellTopologyData> >("Cell Topology",Teuchos::rcp(new CellTopologyData(meshSpecs.ctd)));
 
     ev = Teuchos::rcp(new GatherVerticallyAveragedVelocity<EvalT,PHAL::AlbanyTraits>(*p,dl));
@@ -1516,12 +1513,17 @@ StokesFOBase::constructStokesFOBaseResponsesEvaluators (PHX::FieldManager<PHAL::
 
     // ----------------------- Responses --------------------- //
     paramList->set<Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
+    paramList->set<Teuchos::ParameterList>("LandIce Physical Parameters List", params->sublist("LandIce Physical Parameters"));
+    paramList->set<std::string>("Coordinate Vector Side Variable Name", Albany::coord_vec_name + " " + basalSideName);
     paramList->set<std::string>("Basal Friction Coefficient Name","beta");
     paramList->set<std::string>("Stiffening Factor Gradient Name","stiffening_factor_" + basalSideName + " Gradient");
     paramList->set<std::string>("Stiffening Factor Name", "stiffening_factor_" + basalSideName);
     paramList->set<std::string>("Thickness Gradient Name", "ice_thickness_" + basalSideName + " Gradient");
     paramList->set<std::string>("Thickness Side QP Variable Name","ice_thickness_" + basalSideName);
+    paramList->set<std::string>("Thickness Side Variable Name","ice_thickness_" + basalSideName);
+    paramList->set<std::string>("Bed Topography Side Variable Name","bed_topography_" + basalSideName);
     paramList->set<std::string>("Surface Velocity Side QP Variable Name","surface_velocity");
+    paramList->set<std::string>("Averaged Vertical Velocity Side Variable Name","Averaged Velocity");
     paramList->set<std::string>("SMB Side QP Variable Name","surface_mass_balance_" + basalSideName);
     paramList->set<std::string>("SMB RMS Side QP Variable Name","surface_mass_balance_RMS_" + basalSideName);
     paramList->set<std::string>("Flux Divergence Side QP Variable Name","flux_divergence");

--- a/src/LandIce/problems/LandIce_StokesFOBase.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.hpp
@@ -1068,17 +1068,29 @@ void StokesFOBase::constructBasalBCEvaluators (PHX::FieldManager<PHAL::AlbanyTra
     ptr_lambda->setNominalValue(params->sublist("Parameters"),pl->sublist("Basal Friction Coefficient").get<double>(param_name,-1.0));
     fm0.template registerEvaluator<EvalT>(ptr_lambda);
 
-    //--- Shared Parameter for basal friction coefficient: mu ---//
-    p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: mu"));
+    //--- Shared Parameter for basal friction coefficient: muCoulomb ---//
+    p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: muCoulomb"));
 
     param_name = "Coulomb Friction Coefficient";
     p->set<std::string>("Parameter Name", param_name);
     p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
 
-    Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Mu>> ptr_mu;
-    ptr_mu = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Mu>(*p,dl));
-    ptr_mu->setNominalValue(params->sublist("Parameters"),pl->sublist("Basal Friction Coefficient").get<double>(param_name,-1.0));
-    fm0.template registerEvaluator<EvalT>(ptr_mu);
+    Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuCoulomb>> ptr_muC;
+    ptr_muC = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuCoulomb>(*p,dl));
+    ptr_muC->setNominalValue(params->sublist("Parameters"),pl->sublist("Basal Friction Coefficient").get<double>(param_name,-1.0));
+    fm0.template registerEvaluator<EvalT>(ptr_muC);
+
+    //--- Shared Parameter for basal friction coefficient: muPowerLaw ---//
+    p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: muPowerLaw"));
+
+    param_name = "Power Law Coefficient";
+    p->set<std::string>("Parameter Name", param_name);
+    p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
+
+    Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuPowerLaw>> ptr_muP;
+    ptr_muP = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuPowerLaw>(*p,dl));
+    ptr_muP->setNominalValue(params->sublist("Parameters"),pl->sublist("Basal Friction Coefficient").get<double>(param_name,-1.0));
+    fm0.template registerEvaluator<EvalT>(ptr_muP);
 
     //--- Shared Parameter for basal friction coefficient: power ---//
     p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: power"));

--- a/src/LandIce/problems/LandIce_StokesFOHydrology.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOHydrology.hpp
@@ -683,8 +683,8 @@ LandIce::StokesFOHydrology::constructEvaluators (PHX::FieldManager<PHAL::AlbanyT
   p->set<std::string>("Parameter Name", param_name);
   p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
 
-  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,FelixParamEnum,FelixParamEnum::Lambda>> ptr_lambda;
-  ptr_lambda = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,FelixParamEnum,FelixParamEnum::Lambda>(*p,dl));
+  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Lambda>> ptr_lambda;
+  ptr_lambda = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Lambda>(*p,dl));
   ptr_lambda->setNominalValue(params->sublist("Parameters"),params->sublist("LandIce Basal Friction Coefficient").get<double>(param_name,-1.0));
   fm0.template registerEvaluator<EvalT>(ptr_lambda);
 
@@ -695,8 +695,8 @@ LandIce::StokesFOHydrology::constructEvaluators (PHX::FieldManager<PHAL::AlbanyT
   p->set<std::string>("Parameter Name", param_name);
   p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
 
-  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,FelixParamEnum,FelixParamEnum::Mu>> ptr_mu;
-  ptr_mu = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,FelixParamEnum,FelixParamEnum::Mu>(*p,dl));
+  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuCoulomb>> ptr_mu;
+  ptr_mu = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuCoulomb>(*p,dl));
   ptr_mu->setNominalValue(params->sublist("Parameters"),params->sublist("LandIce Basal Friction Coefficient").get<double>(param_name,-1.0));
   fm0.template registerEvaluator<EvalT>(ptr_mu);
 
@@ -707,8 +707,8 @@ LandIce::StokesFOHydrology::constructEvaluators (PHX::FieldManager<PHAL::AlbanyT
   p->set<std::string>("Parameter Name", param_name);
   p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
 
-  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,FelixParamEnum,FelixParamEnum::Power>> ptr_power;
-  ptr_power = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,FelixParamEnum,FelixParamEnum::Power>(*p,dl));
+  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Power>> ptr_power;
+  ptr_power = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Power>(*p,dl));
   ptr_power->setNominalValue(params->sublist("Parameters"),params->sublist("LandIce Basal Friction Coefficient").get<double>(param_name,-1.0));
   fm0.template registerEvaluator<EvalT>(ptr_power);
 
@@ -770,8 +770,8 @@ LandIce::StokesFOHydrology::constructEvaluators (PHX::FieldManager<PHAL::AlbanyT
   p->set<std::string>("Parameter Name", param_name);
   p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
 
-  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,FelixParamEnum,FelixParamEnum::Homotopy>> ptr_homotopy;
-  ptr_homotopy = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,FelixParamEnum,FelixParamEnum::Homotopy>(*p,dl));
+  Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Homotopy>> ptr_homotopy;
+  ptr_homotopy = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Homotopy>(*p,dl));
   ptr_homotopy->setNominalValue(params->sublist("Parameters"),params->sublist("LandIce Viscosity").get<double>(param_name,-1.0));
   fm0.template registerEvaluator<EvalT>(ptr_homotopy);
 

--- a/src/LandIce/problems/LandIce_StokesFOThermoCoupled.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOThermoCoupled.hpp
@@ -1305,8 +1305,8 @@ if (basalSideName!="INVALID")
     p->set<std::string>("Parameter Name", param_name);
     p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
 
-    Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Mu>> ptr_mu;
-    ptr_mu = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Mu>(*p,dl));
+    Teuchos::RCP<LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuCoulomb>> ptr_mu;
+    ptr_mu = Teuchos::rcp(new LandIce::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::MuCoulomb>(*p,dl));
     ptr_mu->setNominalValue(params->sublist("Parameters"),params->sublist("LandIce Basal Friction Coefficient").get<double>(param_name,-1.0));
     fm0.template registerEvaluator<EvalT>(ptr_mu);
 

--- a/src/LandIce/problems/LandIce_StokesFOThermoCoupled.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOThermoCoupled.hpp
@@ -1348,14 +1348,15 @@ if (basalSideName!="INVALID")
 
     ev = Teuchos::rcp(new LandIce::BasalFrictionCoefficient<EvalT,PHAL::AlbanyTraits,false,true,true>(*p,dl_basal));
     fm0.template registerEvaluator<EvalT>(ev);
-  }
 
-  p = Teuchos::rcp(new Teuchos::ParameterList("Gather Averaged Velocity"));
-  p->set<std::string>("Averaged Velocity Name", "Averaged Velocity");
-  p->set<std::string>("Mesh Part", "basalside");
-  p->set<Teuchos::RCP<const CellTopologyData> >("Cell Topology",Teuchos::rcp(new CellTopologyData(meshSpecs.ctd)));
-  ev = Teuchos::rcp(new GatherVerticallyAveragedVelocity<EvalT,PHAL::AlbanyTraits>(*p,dl));
-  fm0.template registerEvaluator<EvalT>(ev);
+    p = Teuchos::rcp(new Teuchos::ParameterList("Gather Averaged Velocity"));
+    p->set<std::string>("Averaged Velocity Name", "Averaged Velocity");
+    p->set<std::string>("Mesh Part", "basalside");
+    p->set<std::string>("Side Set Name", basalSideName);
+    p->set<Teuchos::RCP<const CellTopologyData> >("Cell Topology",Teuchos::rcp(new CellTopologyData(meshSpecs.ctd)));
+    ev = Teuchos::rcp(new GatherVerticallyAveragedVelocity<EvalT,PHAL::AlbanyTraits>(*p,dl));
+    fm0.template registerEvaluator<EvalT>(ev);
+  }
 
   //--- Shared Parameter for Continuation:  ---//
   {

--- a/src/PHAL_Utilities.cpp
+++ b/src/PHAL_Utilities.cpp
@@ -19,7 +19,7 @@ template<> int getDerivativeDimensions<PHAL::AlbanyTraits::Jacobian> (
     const bool extrudedColumnCoupled = pl->isParameter("Extruded Column Coupled in 2D Response") ? pl->get<bool>("Extruded Column Coupled in 2D Response") : false;
     if(extrudedColumnCoupled)
       { //all column is coupled
-        int side_node_count = ms->ctd.side[2].topology->node_count;
+        int side_node_count = ms->ctd.side[3].topology->node_count;
         int node_count = ms->ctd.node_count;
         int numLevels = app->getDiscretization()->getLayeredMeshNumbering()->numLayers+1;
         return app->getNumEquations()*(node_count + side_node_count*numLevels);
@@ -49,7 +49,7 @@ template<> int getDerivativeDimensions<PHAL::AlbanyTraits::Jacobian> (
     const std::string problemName = pl->isType<std::string>("Name") ? pl->get<std::string>("Name") : "";
     if(problemName == "LandIce Coupled FO H 3D")
     { //all column is coupled
-      int side_node_count = app->getEnrichedMeshSpecs()[ebi].get()->ctd.side[2].topology->node_count;
+      int side_node_count = app->getEnrichedMeshSpecs()[ebi].get()->ctd.side[3].topology->node_count;
       int node_count = app->getEnrichedMeshSpecs()[ebi].get()->ctd.node_count;
       int numLevels = app->getDiscretization()->getLayeredMeshNumbering()->numLayers+1;
       return app->getNumEquations()*(node_count + side_node_count*numLevels);

--- a/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
+++ b/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
@@ -79,6 +79,7 @@ public:
   GatherScalarExtruded2DNodalParameter(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl) :
     GatherScalarNodalParameterBase<EvalT, Traits>(p, dl) {
     fieldLevel = p.get<int>("Field Level");
+    this->setName("Gather Extruded 2D Nodal Parameter" );
   }
 
   void evaluateFields(typename Traits::EvalData d);

--- a/tests/small/LandIce/FO_GIS/CMakeLists.txt
+++ b/tests/small/LandIce/FO_GIS/CMakeLists.txt
@@ -47,6 +47,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_adjoint_sensitivity_thic
                ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_adjoint_sensitivity_thickness.yaml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_adjoint_sensitivity_thicknessT.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_adjoint_sensitivity_thicknessT.yaml COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_analysis_stiffening.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_analysis_stiffening.yaml COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_analysis_stiffeningT.yaml
@@ -124,6 +126,7 @@ add_test(${testName}_GisAdjointSensitivityStiffeningBasalFrictionTpetra ${Albany
 add_test(${testName}_GisSensSMBwrtBetaTpetra ${AlbanyT.exe} input_fo_gis_beta_smbT.yaml)
   if (ALBANY_MESH_DEPENDS_ON_PARAMETERS)
     add_test(${testName}_GisAdjointSensitivityThicknessTpetra ${AlbanyT.exe} input_fo_gis_adjoint_sensitivity_thicknessT.yaml)
+    add_test(${testName}_GisAdjointSensitivityThicknessMoveSurfHeightTpetra ${AlbanyT.exe} input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml)
     add_test(${testName}_GisAdjointSensitivityTwoParametersTpetra ${AlbanyT.exe} input_fo_gis_analysis_two_paramsT.yaml)
   endif()
   if (ALBANY_MESH_DEPENDS_ON_SOLUTION)

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness.yaml
@@ -8,6 +8,7 @@ ANONYMOUS:
     Solution Method: Steady
     Name: LandIce Stokes First Order 3D
     Extruded Column Coupled in 2D Response: true
+    Adjust Bed Topography to Account for Thickness Changes: true
     Required Fields: [temperature]
     Basal Side Name: basalside
     Surface Side Name: upperside

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml
@@ -9,7 +9,7 @@ ANONYMOUS:
     Name: LandIce Stokes First Order 3D
     Compute Sensitivities: true
     Extruded Column Coupled in 2D Response: true
-    Adjust Bed Topography to Account for Thickness Changes: true
+    Adjust Surface Height to Account for Thickness Changes: true
     Required Fields: [temperature]
     Basal Side Name: basalside
     Surface Side Name: upperside
@@ -169,10 +169,10 @@ ANONYMOUS:
             File Name: ../AsciiMeshes/GisUnstructFiles/velocity_RMS.ascii
   Regression Results: 
     Number of Comparisons: 1
-    Test Values: [3.84916158675999966e+01]
+    Test Values: [7.296804392367e-01]
     Sensitivity Comparisons 0: 
       Number of Sensitivity Comparisons: 1
-      Sensitivity Test Values 0: [2.34701347967999993e+02]
+      Sensitivity Test Values 0: [1.046203575608e+00]
     Relative Tolerance: 1.00000000000000005e-04
     Absolute Tolerance: 1.00000000000000005e-04
   Piro: 

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_thickness.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_thickness.yaml
@@ -8,6 +8,7 @@ ANONYMOUS:
     Solution Method: Steady
     Name: LandIce Stokes First Order 3D
     Extruded Column Coupled in 2D Response: true
+    Adjust Bed Topography to Account for Thickness Changes: true
     Required Fields: [temperature]
     Basal Side Name: basalside
     Surface Side Name: upperside

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_params.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_params.yaml
@@ -8,6 +8,7 @@ ANONYMOUS:
     Solution Method: Steady
     Name: LandIce Stokes First Order 3D
     Extruded Column Coupled in 2D Response: true
+    Adjust Bed Topography to Account for Thickness Changes: true
     Required Fields: [temperature]
     Basal Side Name: basalside
     Surface Side Name: upperside

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_paramsT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_paramsT.yaml
@@ -9,6 +9,7 @@ ANONYMOUS:
     Name: LandIce Stokes First Order 3D
     Compute Sensitivities: true
     Extruded Column Coupled in 2D Response: true
+    Adjust Bed Topography to Account for Thickness Changes: true
     Required Fields: [temperature]
     Basal Side Name: basalside
     Surface Side Name: upperside

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smb.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smb.yaml
@@ -8,6 +8,7 @@ ANONYMOUS:
     Solution Method: Continuation
     Name: LandIce Stokes First Order 3D
     Extruded Column Coupled in 2D Response: true
+    Adjust Bed Topography to Account for Thickness Changes: true
     Required Fields: [temperature]
     Basal Side Name: basalside
     Surface Side Name: upperside

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smbT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smbT.yaml
@@ -9,6 +9,7 @@ ANONYMOUS:
     Name: LandIce Stokes First Order 3D
     Compute Sensitivities: true
     Extruded Column Coupled in 2D Response: true
+    Adjust Bed Topography to Account for Thickness Changes: true
     Required Fields: [temperature]
     Basal Side Name: basalside
     Surface Side Name: upperside

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smb_restart.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smb_restart.yaml
@@ -8,6 +8,7 @@ ANONYMOUS:
     Solution Method: Continuation
     Name: LandIce Stokes First Order 3D
     Extruded Column Coupled in 2D Response: true
+    Adjust Bed Topography to Account for Thickness Changes: true
     Required Fields: [temperature, ice_thickness, surface_height]
     Basal Side Name: basalside
     Surface Side Name: upperside


### PR DESCRIPTION
Miscellaneous changes including 
- modifications do the ExtrudedMeshStruct to extrude side sets and node sets of the basal mesh
-  (LandIce) bug fix for wedge elements
-  (LandIce) changes to the gather of VerticallyAveragedVelocity so that the evaluated field is defined on sides
-  (LandIce) modifications to the UpdateZCoordinate