### PR TITLE
Fix 399

### DIFF
--- a/src/Aeras/evaluators/Aeras_ComputeBasisFunctions.hpp
+++ b/src/Aeras/evaluators/Aeras_ComputeBasisFunctions.hpp
@@ -4,19 +4,20 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#ifndef AERAS_COMPUTEBASISFUNCTIONS_HPP
-#define AERAS_COMPUTEBASISFUNCTIONS_HPP
+#ifndef AERAS_COMPUTE_BASIS_FUNCTIONS_HPP
+#define AERAS_COMPUTE_BASIS_FUNCTIONS_HPP
 
 #include "Phalanx_config.hpp"
 #include "Phalanx_Evaluator_WithBaseImpl.hpp"
 #include "Phalanx_Evaluator_Derived.hpp"
 #include "Phalanx_MDField.hpp"
-
-#include "Aeras_Layouts.hpp"
-#include "PHAL_Utilities.hpp"
-
 #include "Intrepid2_CellTools.hpp"
 #include "Intrepid2_Cubature.hpp"
+
+#include "Albany_ScalarOrdinalTypes.hpp"
+#include "PHAL_Dimension.hpp"
+#include "PHAL_Utilities.hpp"
+#include "Aeras_Layouts.hpp"
 
 namespace Albany { class StateManager; }
 
@@ -30,15 +31,14 @@ namespace Aeras {
 
 template<typename EvalT, typename Traits>
 class ComputeBasisFunctions : public PHX::EvaluatorWithBaseImpl<Traits>,
- 			 public PHX::EvaluatorDerived<EvalT, Traits>  {
-
+ 			                        public PHX::EvaluatorDerived<EvalT, Traits>  {
 public:
 
   ComputeBasisFunctions(const Teuchos::ParameterList& p,
-                              const Teuchos::RCP<Aeras::Layouts>& dl);
+                        const Teuchos::RCP<Aeras::Layouts>& dl);
 
   void postRegistrationSetup(typename Traits::SetupData d,
-                      PHX::FieldManager<Traits>& vm);
+                             PHX::FieldManager<Traits>& vm);
 
   void evaluateFields(typename Traits::EvalData d);
 
@@ -135,10 +135,9 @@ public:
   
   KOKKOS_INLINE_FUNCTION
   void compute_lambda_and_theta_nodal (const int cell) const;
-
-
-#endif
+#endif // ALBANY_KOKKOS_UNDER_DEVELOPMENT
 };
-}
 
-#endif
+} // namespace Aeras
+
+#endif // AERAS_COMPUTE_BASIS_FUNCTIONS_HPP

--- a/src/Aeras/problems/Aeras_Layouts.hpp
+++ b/src/Aeras/problems/Aeras_Layouts.hpp
@@ -7,12 +7,8 @@
 #ifndef AERAS_LAYOUTS_HPP
 #define AERAS_LAYOUTS_HPP
 
-#include <vector>
-#include <string>
-
 #include "Teuchos_RCP.hpp"
 
-#include "Albany_DataTypes.hpp"
 #include "Albany_Layouts.hpp"
 
 namespace Aeras {
@@ -36,4 +32,4 @@ namespace Aeras {
   };
 }
 
-#endif 
+#endif // AERAS_LAYOUTS_HPP

--- a/src/LandIce/evaluators/LandIce_BasalMeltRate.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalMeltRate.hpp
@@ -36,7 +36,7 @@ namespace LandIce
 
     // Input:
     PHX::MDField<const ScalarT,Cell,Side,Node>              phi;  // []
-    PHX::MDField<const ScalarT,Cell,Side,Node>    	        beta;  // [kPa yr/m]
+    PHX::MDField<const VelocityType,Cell,Side,Node>    	    beta;  // [kPa yr/m]
     PHX::MDField<const VelocityType,Cell,Side,Node,VecDim>  velocity; // [m/yr]
     PHX::MDField<const ParamScalarT,Cell,Side,Node>         geoFluxHeat; // [W m^{-2}] = [Pa m s^{-1}]
     PHX::MDField<const ScalarT,Cell,Side,Node> 	            Enthalpy; //[MW s m^{-3}]

--- a/src/LandIce/evaluators/LandIce_EnthalpyBasalResid.hpp
+++ b/src/LandIce/evaluators/LandIce_EnthalpyBasalResid.hpp
@@ -41,7 +41,7 @@ namespace LandIce
 
     // Input:
     PHX::MDField<const ParamScalarT,Cell,Side,QuadPoint>       geoFlux;     // [W m^{-2}] = [Pa m s^{-1}]
-    PHX::MDField<const ScalarT,Cell,Side,QuadPoint>            beta; // [kPa m / yr]
+    PHX::MDField<const Type,Cell,Side,QuadPoint>               beta; // [kPa m / yr]
     PHX::MDField<const ScalarT,Cell,Side,QuadPoint>            basal_dTdz; // [K  km^{-1}]
     PHX::MDField<const ScalarT,Cell,Side, QuadPoint>           enthalpy;  //[MW s m^{-3}]
     PHX::MDField<const ParamScalarT,Cell, Side, QuadPoint>     enthalpyHs;  //[MW s m^{-3}]

--- a/src/LandIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
@@ -8,7 +8,10 @@
 #include "Teuchos_TestForException.hpp"
 #include "Phalanx_DataLayout.hpp"
 #include "Teuchos_CommHelpers.hpp"
+
 #include "PHAL_Utilities.hpp"
+
+#include "LandIce_ResponseSMBMismatch.hpp"
 
 template<typename EvalT, typename Traits>
 LandIce::ResponseSMBMismatch<EvalT, Traits>::

--- a/src/LandIce/evaluators/LandIce_StokesFOBodyForce_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOBodyForce_Def.hpp
@@ -10,6 +10,7 @@
 #include "Phalanx_TypeStrings.hpp"
 #include "Sacado.hpp"
 
+#include "LandIce_StokesFOBodyForce.hpp"
 
 //uncomment the following line if you want debug output to be printed to screen
 //#define OUTPUT_TO_SCREEN

--- a/src/LandIce/evaluators/LandIce_UpdateZCoordinate.hpp
+++ b/src/LandIce/evaluators/LandIce_UpdateZCoordinate.hpp
@@ -4,26 +4,23 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#ifndef LANDICE_UPDATEZCOORDINATE_HPP
-#define LANDICE_UPDATEZCOORDINATE_HPP
+#ifndef LANDICE_UPDATE_Z_COORDINATE_HPP
+#define LANDICE_UPDATE_Z_COORDINATE_HPP
 
 #include "Phalanx_config.hpp"
 #include "Phalanx_Evaluator_WithBaseImpl.hpp"
 #include "Phalanx_Evaluator_Derived.hpp"
 #include "Phalanx_MDField.hpp"
 #include "Sacado_ParameterAccessor.hpp" 
+
 #include "Albany_Layouts.hpp"
+#include "PHAL_Dimension.hpp"
 
 namespace LandIce {
-/** \brief Finite Element Interpolation Evaluator
-
-    This evaluator interpolates nodal DOF values to quad points.
-
-*/
 
 template<typename EvalT, typename Traits>
 class UpdateZCoordinateMovingTop : public PHX::EvaluatorWithBaseImpl<Traits>,
-		    public PHX::EvaluatorDerived<EvalT, Traits> {
+		                               public PHX::EvaluatorDerived<EvalT, Traits> {
 
 public:
 
@@ -33,33 +30,32 @@ public:
   UpdateZCoordinateMovingTop(const Teuchos::ParameterList& p,
             const Teuchos::RCP<Albany::Layouts>& dl);
 
-  void postRegistrationSetup(typename Traits::SetupData d,
-                      PHX::FieldManager<Traits>& vm);
+  void postRegistrationSetup(typename Traits::SetupData /* d */,
+                      PHX::FieldManager<Traits>& /* vm */) {}
 
   void evaluateFields(typename Traits::EvalData d);
 
 private:
 
   // Input:
-  PHX::MDField<const MeshScalarT, Cell, Node,Dim> coordVecIn;
-  PHX::MDField<const MeshScalarT, Cell, Node> bedTopo;
-  PHX::MDField<const MeshScalarT, Cell, Node> H;
-  PHX::MDField<const MeshScalarT, Cell, Node> H0;
-  PHX::MDField<const MeshScalarT, Cell, Node> dH;
-  PHX::MDField<MeshScalarT, Cell, Node> topSurface;
+  PHX::MDField<const MeshScalarT, Cell, Node,Dim>   coordVecIn;
+  PHX::MDField<const MeshScalarT, Cell, Node>       bedTopo;
+  PHX::MDField<const MeshScalarT, Cell, Node>       H;
+  PHX::MDField<const MeshScalarT, Cell, Node>       H0;
+  PHX::MDField<const MeshScalarT, Cell, Node>       dH;
 
   // Output:
-  PHX::MDField<MeshScalarT, Cell, Node, Dim> coordVecOut;
+  PHX::MDField<MeshScalarT, Cell, Node>       topSurface;
+  PHX::MDField<MeshScalarT, Cell, Node, Dim>  coordVecOut;
 
   bool haveThickness;
   double minH, rho_i, rho_w;
   unsigned int numDims, numNodes;
 };
 
-
 template<typename EvalT, typename Traits>
 class UpdateZCoordinateMovingBed : public PHX::EvaluatorWithBaseImpl<Traits>,
-        public PHX::EvaluatorDerived<EvalT, Traits> {
+                                   public PHX::EvaluatorDerived<EvalT, Traits> {
 
 public:
 
@@ -69,28 +65,29 @@ public:
   UpdateZCoordinateMovingBed(const Teuchos::ParameterList& p,
             const Teuchos::RCP<Albany::Layouts>& dl);
 
-  void postRegistrationSetup(typename Traits::SetupData d,
-                      PHX::FieldManager<Traits>& vm);
+  void postRegistrationSetup(typename Traits::SetupData /* d */,
+                      PHX::FieldManager<Traits>& /* vm */) {}
 
   void evaluateFields(typename Traits::EvalData d);
 
 private:
 
   // Input:
-  PHX::MDField<const MeshScalarT, Cell, Node,Dim> coordVecIn;
-  PHX::MDField<const MeshScalarT, Cell, Node> dH;
-  PHX::MDField<const MeshScalarT, Cell, Node> bedTopo;
-  PHX::MDField<const MeshScalarT, Cell, Node> topSurface;
-  PHX::MDField<const MeshScalarT, Cell, Node> H;
+  PHX::MDField<const MeshScalarT, Cell, Node,Dim>   coordVecIn;
+  PHX::MDField<const MeshScalarT, Cell, Node>       dH;
+  PHX::MDField<const MeshScalarT, Cell, Node>       bedTopo;
+  PHX::MDField<const MeshScalarT, Cell, Node>       topSurface;
+  PHX::MDField<const MeshScalarT, Cell, Node>       H;
 
   // Output:
-  PHX::MDField<MeshScalarT, Cell, Node, Dim> coordVecOut;
-  PHX::MDField<MeshScalarT, Cell, Node> topSurfaceOut;
-  PHX::MDField<MeshScalarT, Cell, Node> bedTopoOut;
+  PHX::MDField<MeshScalarT, Cell, Node, Dim>  coordVecOut;
+  PHX::MDField<MeshScalarT, Cell, Node>       topSurfaceOut;
+  PHX::MDField<MeshScalarT, Cell, Node>       bedTopoOut;
 
   double minH, rho_i, rho_w;
   unsigned int numDims, numNodes;
 };
-}
 
-#endif
+} // namespace LandIce
+
+#endif // LANDICE_UPDATE_Z_COORDINATE_HPP

--- a/src/LandIce/evaluators/LandIce_UpdateZCoordinate_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_UpdateZCoordinate_Def.hpp
@@ -9,8 +9,12 @@
 #include "Phalanx_DataLayout.hpp"
 
 #include "Albany_Layouts.hpp"
-
 #include "Albany_TpetraThyraUtils.hpp"
+#include "Albany_AbstractMeshStruct.hpp"
+#include "Albany_NodalDOFManager.hpp"
+#include "PHAL_AlbanyTraits.hpp"
+
+#include "LandIce_UpdateZCoordinate.hpp"
 
 //uncomment the following line if you want debug output to be printed to screen
 //#define OUTPUT_TO_SCREEN
@@ -20,8 +24,8 @@ namespace LandIce {
 //**********************************************************************
 template<typename EvalT, typename Traits>
 UpdateZCoordinateMovingTop<EvalT, Traits>::
-UpdateZCoordinateMovingTop(const Teuchos::ParameterList& p,
-            const Teuchos::RCP<Albany::Layouts>& dl) :
+UpdateZCoordinateMovingTop (const Teuchos::ParameterList& p,
+                            const Teuchos::RCP<Albany::Layouts>& dl) :
   coordVecIn (p.get<std::string> ("Old Coords Name"), dl->vertices_vector),
   coordVecOut(p.get<std::string> ("New Coords Name"), dl->vertices_vector),
   topSurface(p.get<std::string>("Top Surface Name"), dl->node_scalar),
@@ -60,17 +64,6 @@ UpdateZCoordinateMovingTop(const Teuchos::ParameterList& p,
 //**********************************************************************
 template<typename EvalT, typename Traits>
 void UpdateZCoordinateMovingTop<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d,
-                      PHX::FieldManager<Traits>& fm)
-{
-}
-
-//**********************************************************************
-//Kokkos functors
-
-//**********************************************************************
-template<typename EvalT, typename Traits>
-void UpdateZCoordinateMovingTop<EvalT, Traits>::
 evaluateFields(typename Traits::EvalData workset)
 {
   auto nodeID = workset.wsElNodeEqID;
@@ -78,7 +71,7 @@ evaluateFields(typename Traits::EvalData workset)
   Teuchos::ArrayRCP<const ST> xT_constView = xT->get1dView();
 
   const Albany::LayeredMeshNumbering<LO>& layeredMeshNumbering = *workset.disc->getLayeredMeshNumbering();
-  const Albany::NodalDOFManager& solDOFManager = workset.disc->getOverlapDOFManager("ordinary_solution");
+  // const Albany::NodalDOFManager& solDOFManager = workset.disc->getOverlapDOFManager("ordinary_solution");
 
   int numLayers = layeredMeshNumbering.numLayers;
   const Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO> >& wsElNodeID  = workset.disc->getWsElNodeID()[workset.wsIndex];
@@ -90,8 +83,8 @@ evaluateFields(typename Traits::EvalData workset)
 
   for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
     const Teuchos::ArrayRCP<GO>& elNodeID = wsElNodeID[cell];
-    const int neq = nodeID.dimension(2);
-    const std::size_t num_dof = neq * this->numNodes;
+    // const int neq = nodeID.dimension(2);
+    // const std::size_t num_dof = neq * this->numNodes;
 
     for (std::size_t node = 0; node < this->numNodes; ++node) {
       LO lnodeId = workset.disc->getOverlapNodeMapT()->getLocalElement(elNodeID[node]);
@@ -121,8 +114,8 @@ evaluateFields(typename Traits::EvalData workset)
 //**********************************************************************
 template<typename EvalT, typename Traits>
 UpdateZCoordinateMovingBed<EvalT, Traits>::
-UpdateZCoordinateMovingBed(const Teuchos::ParameterList& p,
-            const Teuchos::RCP<Albany::Layouts>& dl) :
+UpdateZCoordinateMovingBed (const Teuchos::ParameterList& p,
+                            const Teuchos::RCP<Albany::Layouts>& dl) :
   coordVecIn (p.get<std::string> ("Old Coords Name"), dl->vertices_vector),
   coordVecOut(p.get<std::string> ("New Coords Name"), dl->vertices_vector),
   H(p.get<std::string> ("Thickness Name"), dl->node_scalar),
@@ -156,14 +149,6 @@ UpdateZCoordinateMovingBed(const Teuchos::ParameterList& p,
 }
 
 //**********************************************************************
-template<typename EvalT, typename Traits>
-void UpdateZCoordinateMovingBed<EvalT, Traits>::
-postRegistrationSetup(typename Traits::SetupData d,
-                      PHX::FieldManager<Traits>& fm)
-{
-}
-
-//**********************************************************************
 //Kokkos functors
 
 //**********************************************************************
@@ -176,7 +161,7 @@ evaluateFields(typename Traits::EvalData workset)
   Teuchos::ArrayRCP<const ST> xT_constView = xT->get1dView();
 
   const Albany::LayeredMeshNumbering<LO>& layeredMeshNumbering = *workset.disc->getLayeredMeshNumbering();
-  const Albany::NodalDOFManager& solDOFManager = workset.disc->getOverlapDOFManager("ordinary_solution");
+  // const Albany::NodalDOFManager& solDOFManager = workset.disc->getOverlapDOFManager("ordinary_solution");
 
   int numLayers = layeredMeshNumbering.numLayers;
   const Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO> >& wsElNodeID  = workset.disc->getWsElNodeID()[workset.wsIndex];
@@ -188,9 +173,8 @@ evaluateFields(typename Traits::EvalData workset)
 
   for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
     const Teuchos::ArrayRCP<GO>& elNodeID = wsElNodeID[cell];
-    const int neq = nodeID.dimension(2); 
-    const std::size_t num_dof = neq * this->numNodes;
-
+    // const int neq = nodeID.dimension(2); 
+    // const std::size_t num_dof = neq * this->numNodes;
 
     for (std::size_t node = 0; node < this->numNodes; ++node) {
       LO lnodeId = workset.disc->getOverlapNodeMapT()->getLocalElement(elNodeID[node]);
@@ -223,4 +207,4 @@ evaluateFields(typename Traits::EvalData workset)
   }
 }
 
-} 
+}  // namespace LandIce

--- a/src/LandIce/problems/LandIce_ProblemUtils.hpp
+++ b/src/LandIce/problems/LandIce_ProblemUtils.hpp
@@ -29,6 +29,12 @@ inline std::string bc2str (const LandIceBC bc) {
   return str;
 }
 
+constexpr const char* INVALID_STR = "__INVALID__";
+
+inline bool isInvalid (const std::string& str) {
+  return str==INVALID_STR;
+}
+
 } // namespace LandIce
 
 #endif // LANDICE_PROBLEM_UTILS_HPP

--- a/src/LandIce/problems/LandIce_ProblemUtils.hpp
+++ b/src/LandIce/problems/LandIce_ProblemUtils.hpp
@@ -2,38 +2,135 @@
 #define LANDICE_PROBLEM_UTILS_HPP
 
 #include <string>
+#include <type_traits>
+
+#include "Teuchos_CompilerCodeTweakMacros.hpp"
+#include "Teuchos_TestForException.hpp"
 
 namespace LandIce {
 
-enum class LandIceBC {
+// -------- Invalid string utility -------- //
+
+// Define an invalid string in one place (to avoid typos-related bugs).
+constexpr const char* INVALID_STR = "__INVALID__";
+
+inline bool isInvalid (const std::string& str) {
+  return str==INVALID_STR;
+}
+
+// Extract underlying integer value from an enum
+template<typename EnumType>
+typename std::underlying_type<EnumType>::type etoi (const EnumType e) {
+  return static_cast<typename std::underlying_type<EnumType>::type>(e);
+}
+
+// -------- LandIce boundary conditions -------- //
+
+enum class LandIceBC : int {
   BasalFriction,
   Lateral,
   SynteticTest
 };
 
 inline std::string bc2str (const LandIceBC bc) {
-  std::string str;
   switch (bc) {
     case LandIceBC::BasalFriction:
-      str = "Basal Friction";
+      return "Basal Friction";
       break;
     case LandIceBC::Lateral:
-      str = "Basal Friction";
+      return "Basal Friction";
       break;
     case LandIceBC::SynteticTest:
-      str = "Basal Friction";
+      return "Basal Friction";
       break;
     default:
-      str = "__ERROR__";
+      return INVALID_STR;
   }
-  return str;
+  TEUCHOS_UNREACHABLE_RETURN("");
 }
 
-constexpr const char* INVALID_STR = "__INVALID__";
+// -------- Problem automatic evaluator construction utilities -------- //
 
-inline bool isInvalid (const std::string& str) {
-  return str==INVALID_STR;
+// Enums used to indicate some properties of a field (used in automatic interpolation evalutors construction)
+enum class FieldScalarType : int {
+  Real = 0,
+  MeshScalar = 1,
+  ParamScalar = 2,
+  Scalar = 3
+};
+
+inline FieldScalarType& operator|= (FieldScalarType& st1,
+                                   const FieldScalarType& st2)
+{
+  // Return the 'strongest' scalar type. In the enum above, they are ordered per 'strength'.
+  // The idea is that the assignment of a scalar type A from a scalar type B is legal if
+  // A is 'stronger' than B.
+
+  auto st1_int = etoi(st1);
+  auto st2_int = etoi(st2);
+
+  if (st2_int>st1_int) {
+    st1 = st2;
+  }
+
+  return st1;
 }
+
+inline std::string e2str (const FieldScalarType e) {
+  switch (e) {
+    case FieldScalarType::Scalar:       return "Scalar";
+    case FieldScalarType::MeshScalar:   return "MeshScalar";
+    case FieldScalarType::ParamScalar:  return "ParamScalar";
+    case FieldScalarType::Real:         return "Real";
+    default:                            return INVALID_STR;
+  }
+
+  TEUCHOS_UNREACHABLE_RETURN("");
+}
+
+// Mesh entity where a field is located
+enum class FieldLocation : int {
+  Cell,
+  Node
+};
+
+inline std::string e2str (const FieldLocation e) {
+  switch (e) {
+    case FieldLocation::Node:   return "Node";
+    case FieldLocation::Cell:   return "Cell";
+    default:                    return INVALID_STR;
+  }
+
+  TEUCHOS_UNREACHABLE_RETURN("");
+}
+
+inline std::string rank2str (const int rank) {
+  switch (rank) {
+    case 0:   return "Scalar";
+    case 1:   return "Vector";
+    case 2:   return "Tensor";
+    default:  return INVALID_STR;
+  }
+
+  TEUCHOS_UNREACHABLE_RETURN("");
+}
+
+// Enum used to indicate the interpolation request
+enum class InterpolationRequest {
+  QP_VAL,
+  GRAD_QP_VAL,
+  CELL_VAL,
+  CELL_TO_SIDE,
+  CELL_TO_SIDE_IF_DIST_PARAM,
+  SIDE_TO_CELL
+};
+
+// Enum used to request utility evaluators
+enum class UtilityRequest {
+  BFS,
+  NORMALS,
+  QP_COORDS
+};
 
 } // namespace LandIce
 

--- a/src/LandIce/problems/LandIce_StokesFO.cpp
+++ b/src/LandIce/problems/LandIce_StokesFO.cpp
@@ -66,6 +66,12 @@ void StokesFO::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpecsStr
 
     // If effective pressure is a dist param, we also need to project it.
     ss_build_interp_ev[ssName]["effective_pressure"][CELL_TO_SIDE] = is_dist_param["effective_pressure"];
+    ss_field_scalar_type[ssName]["effective_pressure"] = FieldScalarType::ParamScalar;
+  }
+
+  // Set scalar type of thickness
+  if (!isInvalid(basalSideName)) {
+    ss_field_scalar_type[basalSideName]["ice_thickness"] = FieldScalarType::ParamScalar;
   }
 
   // Note: the base class call must be last, since it calls the buildEvaluators method,

--- a/src/LandIce/problems/LandIce_StokesFO.cpp
+++ b/src/LandIce/problems/LandIce_StokesFO.cpp
@@ -57,28 +57,6 @@ StokesFO( const Teuchos::RCP<Teuchos::ParameterList>& params_,
   }
 }
 
-void StokesFO::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpecsStruct> >  meshSpecs,
-                             Albany::StateManager& stateMgr)
-{
-  // Surface velocity diagnostic may require gradient of beta, which requires gradient of effective_pressure
-  for (const auto& pl : landice_bcs[LandIceBC::BasalFriction]) {
-    std::string ssName  = pl->get<std::string>("Side Set Name");
-
-    // If effective pressure is a dist param, we also need to project it.
-    ss_build_interp_ev[ssName]["effective_pressure"][CELL_TO_SIDE] = is_dist_param["effective_pressure"];
-    ss_field_scalar_type[ssName]["effective_pressure"] = FieldScalarType::ParamScalar;
-  }
-
-  // Set scalar type of thickness
-  if (!isInvalid(basalSideName)) {
-    ss_field_scalar_type[basalSideName]["ice_thickness"] = FieldScalarType::ParamScalar;
-  }
-
-  // Note: the base class call must be last, since it calls the buildEvaluators method,
-  //       which needs all the input/requirements maps to be set.
-  StokesFOBase::buildProblem(meshSpecs,stateMgr);
-}
-
 Teuchos::Array< Teuchos::RCP<const PHX::FieldTag> >
 StokesFO::buildEvaluators(
   PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
@@ -196,6 +174,10 @@ StokesFO::getValidProblemParameters () const
   validPL->sublist("Equation Set", false, "");
 
   return validPL;
+}
+
+void StokesFO::setupEvaluatorRequests () {
+  StokesFOBase::setupEvaluatorRequests();
 }
 
 } // namespace LandIce

--- a/src/LandIce/problems/LandIce_StokesFO.hpp
+++ b/src/LandIce/problems/LandIce_StokesFO.hpp
@@ -64,10 +64,6 @@ public:
   //! Each problem must generate it's list of valide parameters
   Teuchos::RCP<const Teuchos::ParameterList> getValidProblemParameters() const;
 
-  //! Build the PDE instantiations, boundary conditions, and initial solution
-  void buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpecsStruct> >  meshSpecs,
-                     Albany::StateManager& stateMgr);
-
 private:
 
   //! Private to prohibit copying
@@ -94,6 +90,8 @@ public:
                                     Albany::FieldManagerChoice FieldManagerChoice);
 
 protected:
+
+  void setupEvaluatorRequests ();
 
   void constructDirichletEvaluators (const Albany::MeshSpecsStruct& meshSpecs);
   void constructNeumannEvaluators (const Teuchos::RCP<Albany::MeshSpecsStruct>& meshSpecs);

--- a/src/LandIce/problems/LandIce_StokesFOBase.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.cpp
@@ -355,8 +355,7 @@ void StokesFOBase::setupEvaluatorRequests ()
     // ... and observed surface velocity ...
     // NOTE: RMS could be either scalar or vector. The states registration should have figure it out (if the field is listed as input).
     requestSideSetInterpolationEvaluator(surfaceSideName, "observed_surface_velocity", 1, FieldLocation::Node, FieldScalarType::ParamScalar, InterpolationRequest::QP_VAL); 
-    auto it = ss_field_rank[surfaceSideName].find("observed_surface_velocity_RMS");
-    const int obs_vel_rms_rank = (it==ss_field_rank[surfaceSideName].end() ? -1 : it->second);
+    const int obs_vel_rms_rank = ss_field_rank[surfaceSideName]["observed_surface_velocity_RMS"];
     requestSideSetInterpolationEvaluator(surfaceSideName, "observed_surface_velocity_RMS", obs_vel_rms_rank, FieldLocation::Node, FieldScalarType::ParamScalar, InterpolationRequest::QP_VAL); 
 
     // ... and BFs

--- a/src/LandIce/problems/LandIce_StokesFOBase.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.cpp
@@ -174,6 +174,11 @@ void StokesFOBase::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpec
     ss_build_interp_ev[surfaceSideName][dof_names[0]][CELL_TO_SIDE] = true;
     ss_build_interp_ev[surfaceSideName][dof_names[0]][QP_VAL] = true;
 
+    // ... and observed surface velocity ...
+    // NOTE: RMS could be either scalar or vector. But don't worry, the states registration phase will figure it out
+    ss_build_interp_ev[surfaceSideName]["observed_surface_velocity"][QP_VAL] = true;
+    ss_build_interp_ev[surfaceSideName]["observed_surface_velocity_RMS"][QP_VAL] = true;
+
     // ... and BFs
     ss_utils_needed[surfaceSideName][BFS] = true;
   }

--- a/src/LandIce/problems/LandIce_StokesFOBase.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.hpp
@@ -1453,13 +1453,9 @@ StokesFOBase::constructStokesFOBaseResponsesEvaluators (PHX::FieldManager<PHAL::
 
     // Figure out if observed surface velocity RMS is scalar (if present at all)
     if (!isInvalid(surfaceSideName)) {
-      auto it1 = stateMgr.getRegisteredSideSetStates().find(surfaceSideName);
-      if (it1!=stateMgr.getRegisteredSideSetStates().end()) {
-        std::string surfEBName = meshSpecs.sideSetMeshSpecs.at(surfaceSideName)[0]->ebName;
-        auto it2 = it1->second.find(surfEBName);
-        if (it2!=it1->second.end()) {
-          auto where = it2->second.find("observed_surface_velocity_RMS");
-          paramList->set<bool>("Scalar RMS",where!=it2->second.end() && where->second->rank()==3);
+      if (is_ss_input_field[surfaceSideName]["observed_surface_velocity_RMS"]) {
+        if (ss_field_rank[surfaceSideName].at("observed_surface_velocity_RMS")==0) {
+          paramList->set<bool>("Scalar RMS",true);
         }
       }
     }
@@ -1475,7 +1471,7 @@ StokesFOBase::constructStokesFOBaseResponsesEvaluators (PHX::FieldManager<PHAL::
     paramList->set<std::string>("Thickness Side QP Variable Name","ice_thickness_" + basalSideName);
     paramList->set<std::string>("Thickness Side Variable Name","ice_thickness_" + basalSideName);
     paramList->set<std::string>("Bed Topography Side Variable Name","bed_topography_" + basalSideName);
-    paramList->set<std::string>("Surface Velocity Side QP Variable Name","surface_velocity");
+    paramList->set<std::string>("Surface Velocity Side QP Variable Name",dof_names[0] + "_" + surfaceSideName);
     paramList->set<std::string>("Averaged Vertical Velocity Side Variable Name","Averaged Velocity");
     paramList->set<std::string>("SMB Side QP Variable Name","surface_mass_balance_" + basalSideName);
     paramList->set<std::string>("SMB RMS Side QP Variable Name","surface_mass_balance_RMS_" + basalSideName);

--- a/src/LandIce/problems/LandIce_StokesFOThickness.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOThickness.cpp
@@ -47,10 +47,6 @@ StokesFOThickness::StokesFOThickness(
   scatter_names[1] = "Scatter " + resid_names[1];
 
   offsetThickness = vecDimFO;
-
-  field_rank[dof_names[1]] = 0;
-  field_location[dof_names[1]] = FieldLocation::Node;
-  field_scalar_type[dof_names[1]] = FieldScalarType::Scalar;
 }
 
 void StokesFOThickness::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpecsStruct> >  meshSpecs,
@@ -58,18 +54,24 @@ void StokesFOThickness::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::Mes
 {
   if (basalSideName!="__INVALID__") {
     // We need BF on the basal side
-    ss_utils_needed[basalSideName][BFS] = true;
+    ss_utils_needed[basalSideName][UtilityRequest::BFS] = true;
 
     // We need to restrict and interpolate velocity, thickness and surface height
-    ss_build_interp_ev[basalSideName][dof_names[0]][CELL_TO_SIDE] = true;
-    ss_build_interp_ev[basalSideName]["ice_thickness"][CELL_TO_SIDE] = true;
-    ss_build_interp_ev[basalSideName]["surface_height"][CELL_TO_SIDE] = true;
+    requestSideSetInterpolationEvaluator(basalSideName, dof_names[0], 1, FieldLocation::Node, FieldScalarType::Scalar, InterpolationRequest::CELL_TO_SIDE);
+    requestSideSetInterpolationEvaluator(basalSideName, "surface_height", 0, FieldLocation::Node, FieldScalarType::MeshScalar, InterpolationRequest::CELL_TO_SIDE);
+    requestSideSetInterpolationEvaluator(basalSideName, "ice_thickness", 0, FieldLocation::Node, FieldScalarType::MeshScalar, InterpolationRequest::CELL_TO_SIDE);
 
-    ss_build_interp_ev[basalSideName][dof_names[0]][QP_VAL] = true;
-    ss_build_interp_ev[basalSideName]["ice_thickness"][QP_VAL] = true;
-    ss_build_interp_ev[basalSideName]["surface_height"][QP_VAL] = true;
+    requestSideSetInterpolationEvaluator(basalSideName, dof_names[0], 1, FieldLocation::Node, FieldScalarType::Scalar, InterpolationRequest::QP_VAL);
+    requestSideSetInterpolationEvaluator(basalSideName, "surface_height", 0, FieldLocation::Node, FieldScalarType::MeshScalar, InterpolationRequest::QP_VAL);
+    requestSideSetInterpolationEvaluator(basalSideName, "ice_thickness", 0, FieldLocation::Node, FieldScalarType::MeshScalar, InterpolationRequest::QP_VAL);
+  }
 
-    ss_field_rank[basalSideName][dof_names[0]] = 0;
+  // Pre-set the scalar type to MeshScalar.
+  field_scalar_type["ice_thickness"] = FieldScalarType::MeshScalar;
+  field_scalar_type["surface_height"] = FieldScalarType::MeshScalar;
+  for (auto& it : ss_field_scalar_type) {
+    it.second["ice_thickness"] = FieldScalarType::MeshScalar;
+    it.second["surface_height"] = FieldScalarType::MeshScalar;
   }
 
   // Note: the base class call must be last, since it calls the buildEvaluators method,

--- a/src/LandIce/problems/LandIce_StokesFOThickness.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOThickness.cpp
@@ -48,7 +48,9 @@ StokesFOThickness::StokesFOThickness(
 
   offsetThickness = vecDimFO;
 
-  field_dim[dof_names[1]] = 0;
+  field_rank[dof_names[1]] = 0;
+  field_location[dof_names[1]] = FieldLocation::Node;
+  field_scalar_type[dof_names[1]] = FieldScalarType::Scalar;
 }
 
 void StokesFOThickness::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpecsStruct> >  meshSpecs,
@@ -67,9 +69,7 @@ void StokesFOThickness::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<Albany::Mes
     ss_build_interp_ev[basalSideName]["ice_thickness"][QP_VAL] = true;
     ss_build_interp_ev[basalSideName]["surface_height"][QP_VAL] = true;
 
-    ss_field_dim[basalSideName][dof_names[0]] = 0;
-    ss_field_dim[basalSideName]["ice_thickness"] = 0;
-    ss_field_dim[basalSideName]["surface_height"] = 0;
+    ss_field_rank[basalSideName][dof_names[0]] = 0;
   }
 
   // Note: the base class call must be last, since it calls the buildEvaluators method,

--- a/src/PHAL_Utilities_Def.hpp
+++ b/src/PHAL_Utilities_Def.hpp
@@ -5,6 +5,7 @@
 //*****************************************************************//
 
 #include <Kokkos_DynRankView.hpp>
+#include "PHAL_AlbanyTraits.hpp"
 
 namespace PHAL {
 

--- a/src/evaluators/interpolation/PHAL_DOFCellToSideQP_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFCellToSideQP_Def.hpp
@@ -29,47 +29,37 @@ DOFCellToSideQPBase(const Teuchos::ParameterList& p,
 
   Teuchos::RCP<Albany::Layouts> dl_side = dl->side_layouts.at(sideSetName);
   std::string layout_str = p.get<std::string>("Data Layout");
+  std::string cell_field_name = p.get<std::string> ("Cell Variable Name");
+  std::string side_field_name = p.get<std::string> ("Side Variable Name");
 
   if (layout_str=="Cell Scalar") {
-    val_cell = decltype(val_cell)(p.get<std::string> ("Cell Variable Name"),
-        dl->cell_scalar2);
-    val_side_qp = decltype(val_side_qp)(p.get<std::string> ("Side Variable Name"),
-        dl_side->qp_scalar);
+    val_cell    = decltype(val_cell)(cell_field_name, dl->cell_scalar2);
+    val_side_qp = decltype(val_side_qp)(side_field_name, dl_side->qp_scalar);
 
     layout = CELL_SCALAR;
   } else if (layout_str=="Cell Vector") {
-    val_cell = decltype(val_cell)(p.get<std::string> ("Cell Variable Name"),
-        dl->cell_vector);
-    val_side_qp = decltype(val_side_qp)(p.get<std::string> ("Side Variable Name"),
-        dl_side->qp_vector);
+    val_cell    = decltype(val_cell)(cell_field_name, dl->cell_vector);
+    val_side_qp = decltype(val_side_qp)(side_field_name, dl_side->qp_vector);
 
     layout = CELL_VECTOR;
   } else if (layout_str=="Cell Tensor") {
-    val_cell = decltype(val_cell)(p.get<std::string> ("Cell Variable Name"),
-        dl->cell_tensor);
-    val_side_qp = decltype(val_side_qp)(p.get<std::string> ("Side Variable Name"),
-        dl_side->qp_tensor);
+    val_cell    = decltype(val_cell)(cell_field_name, dl->cell_tensor);
+    val_side_qp = decltype(val_side_qp)(side_field_name, dl_side->qp_tensor);
 
     layout = CELL_TENSOR;
   } else if (layout_str=="Node Scalar") {
-    val_cell = decltype(val_cell)(p.get<std::string> ("Cell Variable Name"),
-        dl->node_scalar);
-    val_side_qp = decltype(val_side_qp)(p.get<std::string> ("Side Variable Name"),
-        dl_side->qp_scalar);
+    val_cell    = decltype(val_cell)(cell_field_name, dl->node_scalar);
+    val_side_qp = decltype(val_side_qp)(side_field_name, dl_side->qp_scalar);
 
     layout = NODE_SCALAR;
   } else if (layout_str=="Node Vector") {
-    val_cell = decltype(val_cell)(p.get<std::string> ("Cell Variable Name"),
-        dl->node_vector);
-    val_side_qp = decltype(val_side_qp)(p.get<std::string> ("Side Variable Name"),
-        dl_side->qp_vector);
+    val_cell    = decltype(val_cell)(cell_field_name, dl->node_vector);
+    val_side_qp = decltype(val_side_qp)(side_field_name, dl_side->qp_vector);
 
     layout = NODE_VECTOR;
   } else if (layout_str=="Node Tensor") {
-    val_cell = decltype(val_cell)(p.get<std::string> ("Cell Variable Name"),
-        dl->node_tensor);
-    val_side_qp = decltype(val_side_qp)(p.get<std::string> ("Side Variable Name"),
-        dl_side->qp_tensor);
+    val_cell    = decltype(val_cell)(cell_field_name, dl->node_tensor);
+    val_side_qp = decltype(val_side_qp)(side_field_name, dl_side->qp_tensor);
 
     layout = NODE_TENSOR;
   } else {

--- a/src/evaluators/interpolation/PHAL_DOFCellToSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFCellToSide_Def.hpp
@@ -7,6 +7,8 @@
 #include "Teuchos_ParameterList.hpp"
 #include "Phalanx_DataLayout.hpp"
 
+#include "PHAL_DOFCellToSide.hpp"
+
 namespace PHAL {
 
 //**********************************************************************

--- a/src/evaluators/interpolation/PHAL_SideQuadPointsToSideInterpolation_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_SideQuadPointsToSideInterpolation_Def.hpp
@@ -7,6 +7,9 @@
 #include "Phalanx_DataLayout.hpp"
 #include "Phalanx_TypeStrings.hpp"
 
+#include "PHAL_SideQuadPointsToSideInterpolation.hpp"
+#include "Albany_DiscretizationUtils.hpp"
+
 namespace PHAL {
 
 //**********************************************************************
@@ -48,7 +51,7 @@ SideQuadPointsToSideInterpolationBase (const Teuchos::ParameterList& p,
 
 template<typename EvalT, typename Traits, typename ScalarT>
 void SideQuadPointsToSideInterpolationBase<EvalT, Traits, ScalarT>::
-postRegistrationSetup(typename Traits::SetupData d,
+postRegistrationSetup(typename Traits::SetupData /* d */,
                       PHX::FieldManager<Traits>& fm)
 {
   this->utils.setFieldData (field_qp,fm);

--- a/src/problems/Albany_EvaluatorUtils.cpp
+++ b/src/problems/Albany_EvaluatorUtils.cpp
@@ -9,4 +9,4 @@
 #include "Albany_EvaluatorUtils.hpp"
 #include "Albany_EvaluatorUtils_Def.hpp"
 
-PHAL_INSTANTIATE_TEMPLATE_CLASS_WITH_ONE_SCALAR_TYPE(Albany::EvaluatorUtilsBase)
+PHAL_INSTANTIATE_TEMPLATE_CLASS_WITH_ONE_SCALAR_TYPE(Albany::EvaluatorUtilsImpl)

--- a/src/problems/Albany_EvaluatorUtils.hpp
+++ b/src/problems/Albany_EvaluatorUtils.hpp
@@ -30,48 +30,19 @@ namespace Albany {
   /*!
    * \brief Generic Functions to construct evaluators more succinctly
    */
-  template<typename EvalT, typename Traits, typename ScalarT>
+  template<typename Traits>
   class EvaluatorUtilsBase {
-
-   public:
-
-    typedef typename EvalT::MeshScalarT   MeshScalarT;
-    typedef typename EvalT::ParamScalarT  ParamScalarT;
-
-    EvaluatorUtilsBase(Teuchos::RCP<Albany::Layouts> dl);
-
-    const EvaluatorUtilsBase<EvalT,Traits,MeshScalarT>&
-    getMSTUtils()
-    {
-      if (utils_MST==Teuchos::null)
-        utils_MST = Teuchos::rcp(new EvaluatorUtilsBase<EvalT,Traits,MeshScalarT>(dl));
-      return *utils_MST;
-    }
-
-    const EvaluatorUtilsBase<EvalT,Traits,ParamScalarT>&
-    getPSTUtils()
-    {
-      if (utils_PST==Teuchos::null)
-        utils_PST = Teuchos::rcp(new EvaluatorUtilsBase<EvalT,Traits,ParamScalarT>(dl));
-      return *utils_PST;
-    }
-
-    const EvaluatorUtilsBase<EvalT,Traits,RealType>&
-    getRTUtils()
-    {
-      if (utils_RT==Teuchos::null)
-        utils_RT = Teuchos::rcp(new EvaluatorUtilsBase<EvalT,Traits,RealType>(dl));
-      return *utils_RT;
-    }
+    public:
+    virtual ~EvaluatorUtilsBase() = default;
 
     //! Function to create parameter list for construction of GatherSolution
     //! evaluator with standard Field names
     Teuchos::RCP< PHX::Evaluator<Traits> >
-    constructGatherSolutionEvaluator(
+    virtual constructGatherSolutionEvaluator(
        bool isVectorField,
        Teuchos::ArrayRCP<std::string> dof_names,
        Teuchos::ArrayRCP<std::string> dof_names_dot,
-       int offsetToFirstDOF=0) const;
+       int offsetToFirstDOF=0) const = 0;
 
     Teuchos::RCP< PHX::Evaluator<Traits> >
     constructGatherSolutionEvaluator(
@@ -81,6 +52,375 @@ namespace Albany {
        int offsetToFirstDOF=0) const {
       return constructGatherSolutionEvaluator(isVectorField,arcp_str(dof_name),arcp_str(dof_name_dot),offsetToFirstDOF);
     }
+
+    //! Function to create parameter list for construction of GatherSolution
+    //! evaluator with standard Field names.
+    //! Tensor rank of solution variable is 0, 1, or 2
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructGatherSolutionEvaluator(
+       int tensorRank,
+       Teuchos::ArrayRCP<std::string> dof_names,
+       Teuchos::ArrayRCP<std::string> dof_names_dot,
+       int offsetToFirstDOF=0) const = 0;
+
+
+    //! Function to create parameter list for construction of GatherSolution
+    //! evaluator with acceleration terms
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructGatherSolutionEvaluator_withAcceleration(
+       bool isVectorField,
+       Teuchos::ArrayRCP<std::string> dof_names,
+       Teuchos::ArrayRCP<std::string> dof_names_dot, // can be Teuchos::null
+       Teuchos::ArrayRCP<std::string> dof_names_dotdot,
+       int offsetToFirstDOF=0) const = 0;
+
+    //! Function to create parameter list for construction of GatherSolution
+    //! evaluator with acceleration terms.
+    //! Tensor rank of solution variable is 0, 1, or 2
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructGatherSolutionEvaluator_withAcceleration(
+       int tensorRank,
+       Teuchos::ArrayRCP<std::string> dof_names,
+       Teuchos::ArrayRCP<std::string> dof_names_dot, // can be Teuchos::null
+       Teuchos::ArrayRCP<std::string> dof_names_dotdot,
+       int offsetToFirstDOF=0) const = 0;
+
+
+    //! Same as above, but no ability to gather time dependent x_dot field
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructGatherSolutionEvaluator_noTransient(
+       bool isVectorField,
+       Teuchos::ArrayRCP<std::string> dof_names,
+       int offsetToFirstDOF=0) const = 0;
+
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    constructGatherSolutionEvaluator_noTransient(
+       bool isVectorField,
+       const std::string& dof_name,
+       int offsetToFirstDOF=0) const {
+      return constructGatherSolutionEvaluator_noTransient(isVectorField,arcp_str(dof_name),offsetToFirstDOF);
+    }
+
+    //! Same as above, but no ability to gather time dependent x_dot field
+    //! Tensor rank of solution variable is 0, 1, or 2
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructGatherSolutionEvaluator_noTransient(
+       int tensorRank,
+       Teuchos::ArrayRCP<std::string> dof_names,
+       int offsetToFirstDOF=0) const = 0;
+
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    constructGatherSolutionEvaluator_noTransient(
+       int tensorRank,
+       const std::string& dof_name,
+       int offsetToFirstDOF=0) const {
+      return constructGatherSolutionEvaluator_noTransient(tensorRank,Teuchos::ArrayRCP<std::string>(1,dof_name),offsetToFirstDOF);
+    }
+
+    //! Function to create parameter list for construction of ScatterResidual
+    //! evaluator with standard Field names
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructScatterResidualEvaluator(
+       bool isVectorField,
+       Teuchos::ArrayRCP<std::string> resid_names,
+       int offsetToFirstDOF=0, std::string scatterName="Scatter") const = 0;
+
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    constructScatterResidualEvaluator(
+       bool isVectorField,
+       const std::string& resid_name,
+       int offsetToFirstDOF=0, std::string scatterName="Scatter") const {
+      return constructScatterResidualEvaluator (isVectorField,arcp_str(resid_name),offsetToFirstDOF,scatterName);
+    }
+
+    //! Function to create parameter list for construction of ScatterResidual
+    //! evaluator with standard Field names
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructScatterResidualEvaluatorWithExtrudedParams(
+       bool isVectorField,
+       Teuchos::ArrayRCP<std::string> resid_names,
+       Teuchos::RCP<std::map<std::string, int> > extruded_params_levels,
+       int offsetToFirstDOF=0, std::string scatterName="Scatter") const = 0;
+
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    constructScatterResidualEvaluatorWithExtrudedParams(
+       bool isVectorField,
+       const std::string& resid_name,
+       Teuchos::RCP<std::map<std::string, int> > extruded_params_levels,
+       int offsetToFirstDOF=0, std::string scatterName="Scatter") const {
+      return constructScatterResidualEvaluatorWithExtrudedParams (isVectorField,arcp_str(resid_name),extruded_params_levels,offsetToFirstDOF,scatterName);
+    }
+
+    //! Function to create parameter list for construction of ScatterResidual
+    //! evaluator with standard Field names
+    //! Tensor rank of solution variable is 0, 1, or 2
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructScatterResidualEvaluator(
+       int tensorRank,
+       Teuchos::ArrayRCP<std::string> resid_names,
+       int offsetToFirstDOF=0, std::string scatterName="Scatter") const = 0;
+
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    constructScatterResidualEvaluator(
+       int tensorRank,
+       const std::string& resid_name,
+       int offsetToFirstDOF=0, std::string scatterName="Scatter") const {
+      return constructScatterResidualEvaluator(tensorRank,arcp_str(resid_name),offsetToFirstDOF,scatterName);
+    }
+
+#ifdef ALBANY_CONTACT
+    //! Function to create parameter list for construction of MortarContactResidual
+    //! evaluator with standard Field names
+    //! Tensor rank of solution variable is 0, 1, or 2
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructMortarContactResidualEvaluator(
+       Teuchos::ArrayRCP<std::string> resid_names,
+       int offsetToFirstDOF=0) const = 0;
+
+#endif
+
+    //! Function to create parameter list for construction of GatherScalarNodalParameter
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructGatherScalarNodalParameter(
+        const std::string& param_name,
+        const std::string& field_name="") const = 0;
+
+    //! Function to create parameter list for construction of ScatterScalarNodalParameter
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructScatterScalarNodalParameter(
+        const std::string& param_name,
+        const std::string& field_name="") const = 0;
+
+    //! Function to create parameter list for construction of GatherScalarExtruded2DNodalParameter
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructGatherScalarExtruded2DNodalParameter(
+        const std::string& param_name,
+        const std::string& field_name="") const = 0;
+
+    //! Function to create parameter list for construction of ScatterScalarExtruded2DNodalParameter
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructScatterScalarExtruded2DNodalParameter(
+        const std::string& param_name,
+        const std::string& field_name="") const = 0;
+
+    //! Function to create parameter list for construction of DOFInterpolation
+    //! evaluator with standard field names
+    //! AGS Note 10/13: oddsetToFirstDOF is added to DOF evaluators
+    //!  for template specialization of Jacobian evaluation for
+    //   performance. Otherwise it was not needed. With this info,
+    //   the location of the nonzero partial derivatives can be
+    //   computed, and the chain rule is coded with that known sparsity.
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFInterpolationEvaluator(
+        const std::string& dof_names,
+        int offsetToFirstDOF = -1,
+        const bool enableMemoizer = false) const = 0;
+
+    //! Same as above, for Interpolating the Gradient
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFGradInterpolationEvaluator(
+        const std::string& dof_names,
+        int offsetToFirstDOF = -1,
+        const bool enableMemoizer = false) const = 0;
+
+    //! Interpolation functions for vector quantities
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFVecInterpolationEvaluator(
+       const std::string& dof_names, int offsetToFirstDOF=-1) const = 0;
+
+    //! Same as above, for Interpolating the Gradient for Vector quantities
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFVecGradInterpolationEvaluator(
+       const std::string& dof_names, int offsetToFirstDOF=-1) const = 0;
+
+    //! Interpolation functions for Tensor quantities
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFTensorInterpolationEvaluator(
+       const std::string& dof_names, int offsetToFirstDOF=-1) const = 0;
+    //! Same as above, for Interpolating the Gradient for Tensor quantities
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFTensorGradInterpolationEvaluator(
+       const std::string& dof_names, int offsetToFirstDOF=-1) const = 0;
+
+    //! Interpolation functions for scalar quantities defined on a side set
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFInterpolationSideEvaluator(
+        const std::string& dof_names,
+        const std::string& sideSetName,
+        const bool enableMemoizer = false) const = 0;
+
+    //! Interpolation functions for vector defined on a side set
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFVecInterpolationSideEvaluator(
+       const std::string& dof_names,
+       const std::string& sideSetName,
+       const bool enableMemoizer = false) const = 0;
+
+    //! Interpolation functions for gradient of quantities defined on a side set
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFGradInterpolationSideEvaluator(
+      const std::string& dof_names,
+      const std::string& sideSetName,
+      const bool enableMemoizer = false) const = 0;
+
+    //! Interpolation functions for gradient of vector quantities defined on a side set
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFVecGradInterpolationSideEvaluator(
+      const std::string& dof_names,
+      const std::string& sideSetName,
+      const bool enableMemoizer = false) const = 0;
+
+    //! Function to create parameter list for construction of GatherCoordinateVector
+    //! evaluator with standard Field names
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructGatherCoordinateVectorEvaluator(
+        std::string strCurrentDisp="",
+        const bool enableMemoizer = false) const = 0;
+
+    //! Function to create parameter list for construction of MapToPhysicalFrame
+    //! evaluator with standard Field names
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructMapToPhysicalFrameEvaluator(
+        const Teuchos::RCP<shards::CellTopology>& cellType,
+        const Teuchos::RCP<Intrepid2::Cubature<PHX::Device> > cubature,
+        const Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepidBasis = Teuchos::null,
+        const bool enableMemoizer = false) const = 0;
+
+    //! Function to create parameter list for construction of MapToPhysicalFrameSide
+    //! evaluator with standard Field names
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructMapToPhysicalFrameSideEvaluator(
+      const Teuchos::RCP<shards::CellTopology>& cellType,
+      const Teuchos::RCP<Intrepid2::Cubature<PHX::Device> > cubature,
+      const std::string& sideSetName,
+      const bool enableMemoizer = false) const = 0;
+
+    //! Function to create evaluator for restriction to side set
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFCellToSideEvaluator(
+        const std::string& cell_dof_name,
+        const std::string& sideSetName,
+        const std::string& layout,
+        const Teuchos::RCP<shards::CellTopology>& cellType = Teuchos::null,
+        const std::string& side_dof_name = "",
+        const bool enableMemoizer = false) const = 0;
+
+    //! Combo: restriction to side plus interpolation
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFCellToSideQPEvaluator(
+       const std::string& cell_dof_name,
+       const std::string& sideSetName,
+       const std::string& layout,
+       const Teuchos::RCP<shards::CellTopology>& cellType = Teuchos::null,
+       const std::string& side_dof_name = "",
+       const bool enableMemoizer = false) const = 0;
+
+    //! Function to create evaluator for prolongation to cell
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructDOFSideToCellEvaluator(
+       const std::string& side_dof_name,
+       const std::string& sideSetName,
+       const std::string& layout,
+       const Teuchos::RCP<shards::CellTopology>& cellType = Teuchos::null,
+       const std::string& cell_dof_name = "") const = 0;
+
+    //! Function to create evaluator NodesToCellInterpolation (=DOFInterpolation+QuadPointsToCellInterpolation)
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructNodesToCellInterpolationEvaluator(
+        const std::string& dof_name,
+        bool isVectorField = false,
+        const bool enableMemoizer = false) const = 0;
+
+    //! Function to create evaluator QuadPointsToCellInterpolation
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructQuadPointsToCellInterpolationEvaluator(
+        const std::string& dof_name,
+        const Teuchos::RCP<PHX::DataLayout> qp_layout = Teuchos::null,
+        const Teuchos::RCP<PHX::DataLayout> cell_layout = Teuchos::null,
+        const bool enableMemoizer = false) const = 0;
+
+    //! Function to create evaluator QuadPointsToCellInterpolation
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructSideQuadPointsToSideInterpolationEvaluator(
+      const std::string& dof_name,
+      const std::string& sideSetName,
+      const int fieldDim = 0) const = 0;
+
+    //! Function to create parameter list for construction of ComputeBasisFunctions
+    //! evaluator with standard Field names
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructComputeBasisFunctionsEvaluator(
+        const Teuchos::RCP<shards::CellTopology>& cellType,
+        const Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepidBasis,
+        const Teuchos::RCP<Intrepid2::Cubature<PHX::Device> > cubature,
+        const bool enableMemoizer = false) const = 0;
+
+    //! Function to create parameter list for construction of ComputeBasisFunctionsSide
+    //! evaluator with standard Field names
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    virtual constructComputeBasisFunctionsSideEvaluator(
+        const Teuchos::RCP<shards::CellTopology>& cellType,
+        const Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepidBasisSide,
+        const Teuchos::RCP<Intrepid2::Cubature<PHX::Device> > cubatureSide,
+        const std::string& sideSetName,
+        const bool enableMemoizer = false,
+        const bool buildNormals = false) const = 0;
+
+    protected:
+    Teuchos::ArrayRCP<std::string> arcp_str(const std::string& s) const {
+      return Teuchos::ArrayRCP<std::string>(1,s);
+    }
+
+  };
+
+  template<typename EvalT, typename Traits, typename ScalarT>
+  class EvaluatorUtilsImpl : public EvaluatorUtilsBase<Traits> {
+
+   public:
+
+    typedef typename EvalT::MeshScalarT   MeshScalarT;
+    typedef typename EvalT::ParamScalarT  ParamScalarT;
+
+    EvaluatorUtilsImpl(Teuchos::RCP<Albany::Layouts> dl);
+
+    const EvaluatorUtilsBase<Traits>&
+    getMSTUtils() const
+    {
+      if (utils_MST==Teuchos::null)
+        utils_MST = Teuchos::rcp(new EvaluatorUtilsImpl<EvalT,Traits,MeshScalarT>(dl));
+      return *utils_MST;
+    }
+
+    const EvaluatorUtilsBase<Traits>&
+    getPSTUtils() const
+    {
+      if (utils_PST==Teuchos::null)
+        utils_PST = Teuchos::rcp(new EvaluatorUtilsImpl<EvalT,Traits,ParamScalarT>(dl));
+      return *utils_PST;
+    }
+
+    const EvaluatorUtilsBase<Traits>&
+    getRTUtils() const
+    {
+      if (utils_RT==Teuchos::null)
+        utils_RT = Teuchos::rcp(new EvaluatorUtilsImpl<EvalT,Traits,RealType>(dl));
+      return *utils_RT;
+    }
+
+    // Do not hide base class inlined methods
+    using EvaluatorUtilsBase<Traits>::constructGatherSolutionEvaluator;
+    using EvaluatorUtilsBase<Traits>::constructGatherSolutionEvaluator_noTransient;
+    using EvaluatorUtilsBase<Traits>::constructScatterResidualEvaluator;
+    using EvaluatorUtilsBase<Traits>::constructScatterResidualEvaluatorWithExtrudedParams;
+
+    //! Function to create parameter list for construction of GatherSolution
+    //! evaluator with standard Field names
+    Teuchos::RCP< PHX::Evaluator<Traits> >
+    constructGatherSolutionEvaluator(
+       bool isVectorField,
+       Teuchos::ArrayRCP<std::string> dof_names,
+       Teuchos::ArrayRCP<std::string> dof_names_dot,
+       int offsetToFirstDOF=0) const;
 
     //! Function to create parameter list for construction of GatherSolution
     //! evaluator with standard Field names.
@@ -122,14 +462,6 @@ namespace Albany {
        Teuchos::ArrayRCP<std::string> dof_names,
        int offsetToFirstDOF=0) const;
 
-    Teuchos::RCP< PHX::Evaluator<Traits> >
-    constructGatherSolutionEvaluator_noTransient(
-       bool isVectorField,
-       const std::string& dof_name,
-       int offsetToFirstDOF=0) const {
-      return constructGatherSolutionEvaluator_noTransient(isVectorField,arcp_str(dof_name),offsetToFirstDOF);
-    }
-
     //! Same as above, but no ability to gather time dependent x_dot field
     //! Tensor rank of solution variable is 0, 1, or 2
     Teuchos::RCP< PHX::Evaluator<Traits> >
@@ -138,14 +470,6 @@ namespace Albany {
        Teuchos::ArrayRCP<std::string> dof_names,
        int offsetToFirstDOF=0) const;
 
-    Teuchos::RCP< PHX::Evaluator<Traits> >
-    constructGatherSolutionEvaluator_noTransient(
-       int tensorRank,
-       const std::string& dof_name,
-       int offsetToFirstDOF=0) const {
-      return constructGatherSolutionEvaluator_noTransient(tensorRank,Teuchos::ArrayRCP<std::string>(1,dof_name),offsetToFirstDOF);
-    }
-
     //! Function to create parameter list for construction of ScatterResidual
     //! evaluator with standard Field names
     Teuchos::RCP< PHX::Evaluator<Traits> >
@@ -153,14 +477,6 @@ namespace Albany {
        bool isVectorField,
        Teuchos::ArrayRCP<std::string> resid_names,
        int offsetToFirstDOF=0, std::string scatterName="Scatter") const;
-
-    Teuchos::RCP< PHX::Evaluator<Traits> >
-    constructScatterResidualEvaluator(
-       bool isVectorField,
-       const std::string& resid_name,
-       int offsetToFirstDOF=0, std::string scatterName="Scatter") const {
-      return constructScatterResidualEvaluator (isVectorField,arcp_str(resid_name),offsetToFirstDOF,scatterName);
-    }
 
     //! Function to create parameter list for construction of ScatterResidual
     //! evaluator with standard Field names
@@ -170,15 +486,6 @@ namespace Albany {
        Teuchos::ArrayRCP<std::string> resid_names,
        Teuchos::RCP<std::map<std::string, int> > extruded_params_levels,
        int offsetToFirstDOF=0, std::string scatterName="Scatter") const;
-
-    Teuchos::RCP< PHX::Evaluator<Traits> >
-    constructScatterResidualEvaluatorWithExtrudedParams(
-       bool isVectorField,
-       const std::string& resid_name,
-       Teuchos::RCP<std::map<std::string, int> > extruded_params_levels,
-       int offsetToFirstDOF=0, std::string scatterName="Scatter") const {
-      return constructScatterResidualEvaluatorWithExtrudedParams (isVectorField,arcp_str(resid_name),extruded_params_levels,offsetToFirstDOF,scatterName);
-    }
 
     //! Function to create parameter list for construction of ScatterResidual
     //! evaluator with standard Field names
@@ -188,14 +495,6 @@ namespace Albany {
        int tensorRank,
        Teuchos::ArrayRCP<std::string> resid_names,
        int offsetToFirstDOF=0, std::string scatterName="Scatter") const;
-
-    Teuchos::RCP< PHX::Evaluator<Traits> >
-    constructScatterResidualEvaluator(
-       int tensorRank,
-       const std::string& resid_name,
-       int offsetToFirstDOF=0, std::string scatterName="Scatter") const {
-      return constructScatterResidualEvaluator(tensorRank,arcp_str(resid_name),offsetToFirstDOF,scatterName);
-    }
 
 #ifdef ALBANY_CONTACT
     //! Function to create parameter list for construction of MortarContactResidual
@@ -373,7 +672,7 @@ namespace Albany {
     constructSideQuadPointsToSideInterpolationEvaluator(
       const std::string& dof_name,
       const std::string& sideSetName,
-      bool isVectorField = false) const;
+      const int fieldDim = 0) const;
 
     //! Function to create parameter list for construction of ComputeBasisFunctions
     //! evaluator with standard Field names
@@ -397,14 +696,10 @@ namespace Albany {
 
   private:
 
-    Teuchos::ArrayRCP<std::string> arcp_str(const std::string& s) const {
-      return Teuchos::ArrayRCP<std::string>(1,s);
-    }
-
     //! Evaluator Utils with different ScalarType
-    Teuchos::RCP<EvaluatorUtilsBase<EvalT,Traits,MeshScalarT>>    utils_MST;
-    Teuchos::RCP<EvaluatorUtilsBase<EvalT,Traits,ParamScalarT>>   utils_PST;
-    Teuchos::RCP<EvaluatorUtilsBase<EvalT,Traits,RealType>>       utils_RT;
+    mutable Teuchos::RCP<EvaluatorUtilsBase<Traits>>   utils_MST;
+    mutable Teuchos::RCP<EvaluatorUtilsBase<Traits>>   utils_PST;
+    mutable Teuchos::RCP<EvaluatorUtilsBase<Traits>>   utils_RT;
 
     //! Struct of PHX::DataLayout objects defined all together.
     Teuchos::RCP<Albany::Layouts> dl;
@@ -412,7 +707,7 @@ namespace Albany {
   };
 
 template<typename EvalT, typename Traits>
-using EvaluatorUtils = EvaluatorUtilsBase<EvalT,Traits,typename EvalT::ScalarT>;
+using EvaluatorUtils = EvaluatorUtilsImpl<EvalT,Traits,typename EvalT::ScalarT>;
 
 } // Namespace Albany
 

--- a/src/problems/Albany_EvaluatorUtils_Def.hpp
+++ b/src/problems/Albany_EvaluatorUtils_Def.hpp
@@ -42,16 +42,15 @@
 /********************  Problem Utils Class  ******************************/
 
 template<typename EvalT, typename Traits, typename ScalarT>
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::EvaluatorUtilsBase(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::EvaluatorUtilsImpl(
      Teuchos::RCP<Albany::Layouts> dl_) :
      dl(dl_)
 {
 }
 
-
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator(
        bool isVectorField,
        Teuchos::ArrayRCP<std::string> dof_names,
        Teuchos::ArrayRCP<std::string> dof_names_dot,
@@ -79,7 +78,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluat
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator(
        int tensorRank,
        Teuchos::ArrayRCP<std::string> dof_names,
        Teuchos::ArrayRCP<std::string> dof_names_dot,
@@ -104,7 +103,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluat
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator_withAcceleration(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator_withAcceleration(
        bool isVectorField,
        Teuchos::ArrayRCP<std::string> dof_names,
        Teuchos::ArrayRCP<std::string> dof_names_dot,
@@ -141,7 +140,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluat
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator_withAcceleration(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator_withAcceleration(
        int tensorRank,
        Teuchos::ArrayRCP<std::string> dof_names,
        Teuchos::ArrayRCP<std::string> dof_names_dot,
@@ -176,7 +175,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluat
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator_noTransient(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator_noTransient(
        bool isVectorField,
        Teuchos::ArrayRCP<std::string> dof_names,
        int offsetToFirstDOF) const
@@ -202,7 +201,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluat
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator_noTransient(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluator_noTransient(
        int tensorRank,
        Teuchos::ArrayRCP<std::string> dof_names,
        int offsetToFirstDOF) const
@@ -225,7 +224,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherSolutionEvaluat
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherScalarNodalParameter(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructGatherScalarNodalParameter(
        const std::string& param_name,
        const std::string& field_name) const
 {
@@ -246,7 +245,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherScalarNodalPara
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructScatterScalarNodalParameter(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructScatterScalarNodalParameter(
        const std::string& param_name,
        const std::string& field_name) const
 {
@@ -268,7 +267,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructScatterScalarNodalPar
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherScalarExtruded2DNodalParameter(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructGatherScalarExtruded2DNodalParameter(
        const std::string& param_name,
        const std::string& field_name) const
 {
@@ -290,7 +289,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherScalarExtruded2
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructScatterScalarExtruded2DNodalParameter(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructScatterScalarExtruded2DNodalParameter(
        const std::string& param_name,
        const std::string& field_name) const
 {
@@ -313,7 +312,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructScatterScalarExtruded
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructScatterResidualEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructScatterResidualEvaluator(
        bool isVectorField,
        Teuchos::ArrayRCP<std::string> resid_names,
        int offsetToFirstDOF, std::string scatterName) const
@@ -339,7 +338,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructScatterResidualEvalua
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructScatterResidualEvaluatorWithExtrudedParams(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructScatterResidualEvaluatorWithExtrudedParams(
        bool isVectorField,
        Teuchos::ArrayRCP<std::string> resid_names,
        Teuchos::RCP<std::map<std::string, int> > extruded_params_levels,
@@ -367,7 +366,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructScatterResidualEvalua
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructScatterResidualEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructScatterResidualEvaluator(
        int tensorRank,
        Teuchos::ArrayRCP<std::string> resid_names,
        int offsetToFirstDOF, std::string scatterName) const
@@ -391,7 +390,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructScatterResidualEvalua
 #ifdef ALBANY_CONTACT
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructMortarContactResidualEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructMortarContactResidualEvaluator(
        Teuchos::ArrayRCP<std::string> resid_names,
        int offsetToFirstDOF) const
 {
@@ -411,7 +410,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructMortarContactResidual
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherCoordinateVectorEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructGatherCoordinateVectorEvaluator(
     std::string strCurrentDisp, const bool enableMemoizer) const
 {
     using Teuchos::RCP;
@@ -437,7 +436,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructGatherCoordinateVecto
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructMapToPhysicalFrameEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructMapToPhysicalFrameEvaluator(
     const Teuchos::RCP<shards::CellTopology>& cellType,
     const Teuchos::RCP<Intrepid2::Cubature<PHX::Device> > cubature,
     const Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepidBasis,
@@ -466,7 +465,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructMapToPhysicalFrameEva
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructMapToPhysicalFrameSideEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructMapToPhysicalFrameSideEvaluator(
     const Teuchos::RCP<shards::CellTopology>& cellType,
     const Teuchos::RCP<Intrepid2::Cubature<PHX::Device> > cubature,
     const std::string& sideSetName,
@@ -496,7 +495,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructMapToPhysicalFrameSid
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructComputeBasisFunctionsEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructComputeBasisFunctionsEvaluator(
     const Teuchos::RCP<shards::CellTopology>& cellType,
     const Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepidBasis,
     const Teuchos::RCP<Intrepid2::Cubature<PHX::Device> > cubature,
@@ -534,7 +533,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructComputeBasisFunctions
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructComputeBasisFunctionsSideEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructComputeBasisFunctionsSideEvaluator(
     const Teuchos::RCP<shards::CellTopology>& cellType,
     const Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepidBasisSide,
     const Teuchos::RCP<Intrepid2::Cubature<PHX::Device> > cubatureSide,
@@ -579,7 +578,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructComputeBasisFunctions
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFCellToSideEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFCellToSideEvaluator(
     const std::string& cell_dof_name,
     const std::string& sideSetName,
     const std::string& layout,
@@ -612,7 +611,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFCellToSideEvaluato
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFCellToSideQPEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFCellToSideQPEvaluator(
        const std::string& cell_dof_name,
        const std::string& sideSetName,
        const std::string& layout,
@@ -646,7 +645,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFCellToSideQPEvalua
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFSideToCellEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFSideToCellEvaluator(
        const std::string& side_dof_name,
        const std::string& sideSetName,
        const std::string& layout,
@@ -676,7 +675,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFSideToCellEvaluato
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFGradInterpolationEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFGradInterpolationEvaluator(
     const std::string& dof_name, int offsetToFirstDOF, const bool enableMemoizer) const
 {
     using Teuchos::RCP;
@@ -703,7 +702,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFGradInterpolationE
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFGradInterpolationSideEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFGradInterpolationSideEvaluator(
        const std::string& dof_name,
        const std::string& sideSetName,
        const bool enableMemoizer) const
@@ -732,7 +731,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFGradInterpolationS
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFInterpolationEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFInterpolationEvaluator(
     const std::string& dof_name, int offsetToFirstDOF, const bool enableMemoizer) const
 {
     using Teuchos::RCP;
@@ -755,7 +754,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFInterpolationEvalu
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFInterpolationSideEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFInterpolationSideEvaluator(
     const std::string& dof_name, const std::string& sideSetName, const bool enableMemoizer) const
 {
     TEUCHOS_TEST_FOR_EXCEPTION (dl->side_layouts.find(sideSetName)==dl->side_layouts.end(), std::runtime_error,
@@ -781,7 +780,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFInterpolationSideE
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFTensorInterpolationEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFTensorInterpolationEvaluator(
        const std::string& dof_name,
        int offsetToFirstDOF) const
 {
@@ -804,7 +803,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFTensorInterpolatio
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFTensorGradInterpolationEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFTensorGradInterpolationEvaluator(
        const std::string& dof_name,
        int offsetToFirstDOF) const
 {
@@ -830,7 +829,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFTensorGradInterpol
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFVecGradInterpolationEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFVecGradInterpolationEvaluator(
        const std::string& dof_name,
        int offsetToFirstDOF) const
 {
@@ -855,7 +854,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFVecGradInterpolati
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFVecGradInterpolationSideEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFVecGradInterpolationSideEvaluator(
        const std::string& dof_name,
        const std::string& sideSetName,
        const bool enableMemoizer) const
@@ -884,7 +883,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFVecGradInterpolati
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFVecInterpolationEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFVecInterpolationEvaluator(
        const std::string& dof_name,
        int offsetToFirstDOF) const
 {
@@ -907,7 +906,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFVecInterpolationEv
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFVecInterpolationSideEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructDOFVecInterpolationSideEvaluator(
        const std::string& dof_name,
        const std::string& sideSetName,
        const bool enableMemoizer) const
@@ -935,7 +934,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructDOFVecInterpolationSi
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructNodesToCellInterpolationEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructNodesToCellInterpolationEvaluator(
     const std::string& dof_name, bool isVectorField, const bool enableMemoizer) const
 {
   Teuchos::RCP<Teuchos::ParameterList> p;
@@ -957,7 +956,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructNodesToCellInterpolat
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructQuadPointsToCellInterpolationEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructQuadPointsToCellInterpolationEvaluator(
     const std::string& dof_name, const Teuchos::RCP<PHX::DataLayout> qp_layout,
     const Teuchos::RCP<PHX::DataLayout> cell_layout, const bool enableMemoizer) const
 {
@@ -981,10 +980,10 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructQuadPointsToCellInter
 
 template<typename EvalT, typename Traits, typename ScalarT>
 Teuchos::RCP< PHX::Evaluator<Traits> >
-Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructSideQuadPointsToSideInterpolationEvaluator(
+Albany::EvaluatorUtilsImpl<EvalT,Traits,ScalarT>::constructSideQuadPointsToSideInterpolationEvaluator(
   const std::string& dof_name,
   const std::string& sideSetName,
-  bool isVectorField) const
+  const int fieldDim) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION (dl->side_layouts.find(sideSetName)==dl->side_layouts.end(), std::runtime_error,
                               "Error! The layout structure for side set " << sideSetName << " was not found.\n");
@@ -996,7 +995,7 @@ Albany::EvaluatorUtilsBase<EvalT,Traits,ScalarT>::constructSideQuadPointsToSideI
   p->set<std::string>("Field QP Name", dof_name);
   p->set<std::string>("Weighted Measure Name", "Weighted Measure "+sideSetName);
   p->set<std::string>("Side Set Name", sideSetName);
-  p->set<bool>("Is Vector Field", isVectorField);
+  p->set<int>("Field Dimension", fieldDim);
 
   // Output
   p->set<std::string>("Field Side Name", dof_name);


### PR DESCRIPTION
This PR addresses #399 . After the change in Trilinos, the default behavior in Phalanx (for a common trilinos installation for Albany) is to throw if two evaluators try to evaluate the same field.

Obviously, a quick fix is to disable this feature, but I was the one to request it in Trilinos, so you probably can see that I don't like the idea of disabling it. This is because it _can_ indeed be a bug (and a very hard to find one) if two evaluators evaluate the same field.

So we had to do a bunch of fixes to the albany problems, to avoid duplicates. @ikalash already fixed a bunch of these errors in ATO, Aeras and LCM. This PR fixes the LandIce tests.

The PR contains a sizeable refactoring of the StokesFOXYZ classes. The underlying idea is that we want to automatize as much as possible the creation of the evaluators, with the goal to minimize code duplication and facilitate extension of StokesFOBase to other StokesFOXYZ problems.

There is still one test failing (FO_GIS_GisUnstructuredPerformance_Tpetra), where the residual of Newton seems to not really decrease. Not sure why. However. I think this PR should be merged, so that it will allow some tests to stop failing, as well as other LandIce developer to adapt to design changes.